### PR TITLE
Skip duplicate actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,24 @@ on: [push, pull_request]
 
 jobs:
 
+  pre_build:
+
+    runs-on: ubuntu-20.04
+
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+
+    steps:
+      - name: Skip Duplicate Actions
+        id: skip_check
+        uses: fkirc/skip-duplicate-actions@v3.4.1
+        with:
+          skip_after_successful_duplicate: 'true'
+
   build_kernel:
+
+    needs: pre_build
+    if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
 
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
With the default workflow, GitHub Actions are invoked on every push and pull request. This commit adds the functionality to check if a previous successful run is present, then skip re-run for its pull request.