### PR TITLE
NAS-114655 / 22.02 / Implement native NFSv4 ACLs in NFS server (#17)

### DIFF
--- a/fs/nfsd/nfs41acl_xdr.h
+++ b/fs/nfsd/nfs41acl_xdr.h
@@ -1,0 +1,84 @@
+#ifndef _NFS41ACL_H_RPCGEN
+#define _NFS41ACL_H_RPCGEN
+/*
+ * Initially generated through RPCGEN
+ * spec file is used in openzfs to
+ * manage system.nfs4_acl_xdr xattr
+ */
+
+#define NA41_NAME "system.nfs4_acl_xdr"
+
+typedef u_int acetype4;
+#define ACE4_FILE_INHERIT_ACE 0x00000001
+#define ACE4_DIRECTORY_INHERIT_ACE 0x00000002
+#define ACE4_NO_PROPAGATE_INHERIT_ACE 0x00000004
+#define ACE4_INHERIT_ONLY_ACE 0x00000008
+#define ACE4_SUCCESSFUL_ACCESS_ACE_FLAG 0x00000010
+#define ACE4_FAILED_ACCESS_ACE_FLAG 0x00000020
+#define ACE4_IDENTIFIER_GROUP 0x00000040
+#define ACE4_INHERITED_ACE 0x00000080
+#define NFS41_FLAGS	(ACE4_DIRECTORY_INHERIT_ACE| \
+			 ACE4_FILE_INHERIT_ACE| \
+			 ACE4_NO_PROPAGATE_INHERIT_ACE| \
+			 ACE4_INHERIT_ONLY_ACE| \
+			 ACE4_INHERITED_ACE| \
+			 ACE4_IDENTIFIER_GROUP)
+
+typedef u_int aceflag4;
+#define ACEI4_SPECIAL_WHO 0x00000001
+
+typedef u_int aceiflag4;
+#define ACE4_SPECIAL_OWNER 1
+#define ACE4_SPECIAL_GROUP 2
+#define ACE4_SPECIAL_EVERYONE 3
+#define ACE4_SPECIAL_INTERACTIVE 4
+#define ACE4_SPECIAL_NETWORK 5
+#define ACE4_SPECIAL_DIALUP 6
+#define ACE4_SPECIAL_BATCH 7
+#define ACE4_SPECIAL_ANONYMOUS 8
+#define ACE4_SPECIAL_AUTHENTICATED 9
+#define ACE4_SPECIAL_SERVICE 10
+
+typedef u_int acemask4;
+
+struct nfsace4i {
+	acetype4 type;
+	aceflag4 flag;
+	aceiflag4 iflag;
+	acemask4 access_mask;
+	u_int who;
+};
+typedef struct nfsace4i nfsace4i;
+#define NACE41_LEN 5
+#define ACL4_AUTO_INHERIT 0x00000001
+#define ACL4_PROTECTED 0x00000002
+#define ACL4_DEFAULTED 0x00000004
+
+typedef u_int aclflag4;
+
+struct nfsacl41i {
+	aclflag4 na41_flag;
+	struct {
+		u_int na41_aces_len;
+		nfsace4i *na41_aces_val;
+	} na41_aces;
+};
+typedef struct nfsacl41i nfsacl41i;
+
+/*
+ * Macros for sanity checks related to XDR and ACL buffer sizes
+ */
+#define NFS41ACL_MAX_ENTRIES	128
+#define ACE4SIZE                (sizeof (nfsace4i))
+#define XDRBASE                 (2 * sizeof (u32))
+
+#define ACES_TO_SIZE(x, y)      (x + (y * ACE4SIZE))
+#define SIZE_TO_ACES(x, y)      ((y - x) / ACE4SIZE)
+#define SIZE_IS_VALID(x, y)     ((x >= ACES_TO_SIZE(y, 0)) && \
+                                (((x - y) % ACE4SIZE) == 0))
+
+#define ACES_TO_XDRSIZE(x)      (ACES_TO_SIZE(XDRBASE, x))
+#define XDRSIZE_TO_ACES(x)      (SIZE_TO_ACES(XDRBASE, x))
+#define XDRSIZE_IS_VALID(x)     (SIZE_IS_VALID(x, XDRBASE))
+
+#endif /* !_NFS41ACL_H_RPCGEN */

--- a/fs/nfsd/nfs4acl.c
+++ b/fs/nfsd/nfs4acl.c
@@ -37,11 +37,13 @@
 #include <linux/fs.h>
 #include <linux/slab.h>
 #include <linux/posix_acl.h>
+#include <linux/xattr.h>
 
 #include "nfsfh.h"
 #include "nfsd.h"
 #include "acl.h"
 #include "vfs.h"
+#include "nfs41acl_xdr.h"
 
 #define NFS4_ACL_TYPE_DEFAULT	0x01
 #define NFS4_ACL_DIR		0x02
@@ -125,8 +127,8 @@ static short ace2type(struct nfs4_ace *);
 static void _posix_to_nfsv4_one(struct posix_acl *, struct nfs4_acl *,
 				unsigned int);
 
-int
-nfsd4_get_nfs4_acl(struct svc_rqst *rqstp, struct dentry *dentry,
+static int
+get_nfs4_posix_acl(struct svc_rqst *rqstp, struct dentry *dentry,
 		struct nfs4_acl **acl)
 {
 	struct inode *inode = d_inode(dentry);
@@ -174,6 +176,159 @@ out:
 rel_pacl:
 	posix_acl_release(pacl);
 	return error;
+}
+
+static int
+convert_to_nfs40_ace(u32 *xdrbuf, struct nfs4_ace *ace)
+{
+	int error = 0;
+	u32 iflag, id;
+
+	ace->type = ntohl(*(xdrbuf++));
+	if (ace->type > NFS4_ACE_ACCESS_DENIED_ACE_TYPE)
+		return -EINVAL;
+
+	ace->flag = ntohl(*(xdrbuf++));
+	iflag = ntohl(*(xdrbuf++));
+	ace->access_mask = ntohl(*(xdrbuf++)) & NFS4_ACE_MASK_ALL;
+	id = ntohl(*(xdrbuf++));
+
+	if (iflag & ACEI4_SPECIAL_WHO) {
+		switch(id) {
+		case ACE4_SPECIAL_OWNER:
+			ace->whotype = NFS4_ACL_WHO_OWNER;
+			break;
+		case ACE4_SPECIAL_GROUP:
+			ace->whotype = NFS4_ACL_WHO_GROUP;
+			break;
+		case ACE4_SPECIAL_EVERYONE:
+			ace->whotype = NFS4_ACL_WHO_EVERYONE;
+			break;
+		}
+	} else {
+		ace->whotype = NFS4_ACL_WHO_NAMED;
+		if (ace->flag & NFS4_ACE_IDENTIFIER_GROUP) {
+			ace->who_gid = make_kgid(&init_user_ns, id);
+			if (!gid_valid(ace->who_gid)) {
+				error = -EINVAL;
+			}
+		} else {
+			ace->who_uid = make_kuid(&init_user_ns, id);
+			if (!uid_valid(ace->who_uid)) {
+				error = -EINVAL;
+			}
+		}
+	}
+
+	return error;
+}
+
+static int
+convert_nfs41xdr_to_nfs40_acl(u32 *xdrbuf, size_t remaining, struct nfs4_acl *acl)
+{
+	int error = 0;
+	int i;
+
+	for (i = 0; i < acl->naces; i++, xdrbuf += NACE41_LEN) {
+		if (remaining < (NACE41_LEN * sizeof(u32))) {
+			error = -EOVERFLOW;
+			break;
+		}
+
+		error = convert_to_nfs40_ace(xdrbuf, &acl->aces[i]);
+		if (error)
+			break;
+
+		remaining -= (NACE41_LEN * sizeof(u32));
+	}
+
+	BUG_ON(remaining != 0);
+	return error;
+}
+
+static int
+get_nfs4_nfsv41xdr_acl(struct svc_rqst *rqstp, struct dentry *dentry,
+		struct nfs4_acl **pacl)
+{
+	int error = 0;
+	u32 ace_cnt;
+	u32 *xdr_buf = NULL, *p;
+	struct nfs4_acl *acl = NULL;
+	ssize_t len;
+	size_t xdr_buf_sz = ACES_TO_XDRSIZE(NFS41ACL_MAX_ENTRIES);
+
+	xdr_buf = kzalloc(xdr_buf_sz, GFP_KERNEL);
+	if (!xdr_buf)
+		return -ENOMEM;
+
+	len = vfs_getxattr(dentry, NA41_NAME, xdr_buf, xdr_buf_sz);
+	if (len == 0)
+		return -EOPNOTSUPP;
+
+	if (len < 0) {
+		switch (len) {
+		case -EOPNOTSUPP:
+			/* ZFS says NFSv4 ACLs not supported */
+			error = -EOPNOTSUPP;
+			goto out;
+		case -EINVAL:
+			/* ZFS unhappy with buffer size */
+			error = -EINVAL;
+			goto out;
+		case -ERANGE:
+			/* our buffer is too small. This is _very_ unexpected */
+			error = -EINVAL;
+			goto out;
+		case -EPERM:
+		case -EACCES:
+			error = -EPERM;
+			goto out;
+		default:
+			error = -ENOMEM;
+			goto out;
+		}
+	}
+
+	BUG_ON(!(XDRSIZE_IS_VALID(len)));
+
+	/*
+	 * skip first byte since it contains ACL flags that
+	 * aren't used in NFSv4.0 ACLs
+	 */
+	p = xdr_buf + 1;
+	ace_cnt = ntohl(*(p++));
+	if (ace_cnt > NFS41ACL_MAX_ENTRIES) {
+		error = -ERANGE;
+		goto out;
+	}
+
+	acl = kzalloc(nfs4_acl_bytes(ace_cnt), GFP_KERNEL);
+	if (!acl) {
+		error = -ENOMEM;
+		goto out;
+	}
+	acl->naces = ace_cnt;
+
+	error = convert_nfs41xdr_to_nfs40_acl(p++, len - (2 * sizeof(u32)), acl);
+	if (error)
+		kfree(acl);
+	else
+		*pacl = acl;
+out:
+	kfree(xdr_buf);
+	return (error);
+}
+
+int
+nfsd4_get_nfs4_acl(struct svc_rqst *rqstp, struct dentry *dentry,
+		struct nfs4_acl **acl)
+{
+	struct inode *inode = d_inode(dentry);
+
+	if (IS_NFSV4ACL(inode))
+		return get_nfs4_nfsv41xdr_acl(rqstp, dentry, acl);
+	else
+		return get_nfs4_posix_acl(rqstp, dentry, acl);
 }
 
 struct posix_acl_summary {
@@ -751,21 +906,14 @@ out_estate:
 	return ret;
 }
 
-__be32
-nfsd4_set_nfs4_acl(struct svc_rqst *rqstp, struct svc_fh *fhp,
-		struct nfs4_acl *acl)
+static int
+nfsv4_set_posix_acl(struct svc_fh *fhp, struct nfs4_acl *acl)
 {
-	__be32 error;
 	int host_error;
+	unsigned int flags = 0;
+	struct posix_acl *pacl = NULL, *dpacl = NULL;
 	struct dentry *dentry;
 	struct inode *inode;
-	struct posix_acl *pacl = NULL, *dpacl = NULL;
-	unsigned int flags = 0;
-
-	/* Get inode */
-	error = fh_verify(rqstp, fhp, 0, NFSD_MAY_SATTR);
-	if (error)
-		return error;
 
 	dentry = fhp->fh_dentry;
 	inode = d_inode(dentry);
@@ -775,26 +923,153 @@ nfsd4_set_nfs4_acl(struct svc_rqst *rqstp, struct svc_fh *fhp,
 
 	host_error = nfs4_acl_nfsv4_to_posix(acl, &pacl, &dpacl, flags);
 	if (host_error == -EINVAL)
-		return nfserr_attrnotsupp;
+		return (-EOPNOTSUPP);
 	if (host_error < 0)
-		goto out_nfserr;
+		return host_error;
 
 	fh_lock(fhp);
 
 	host_error = set_posix_acl(inode, ACL_TYPE_ACCESS, pacl);
 	if (host_error < 0)
-		goto out_drop_lock;
+		goto out;
 
 	if (S_ISDIR(inode->i_mode)) {
 		host_error = set_posix_acl(inode, ACL_TYPE_DEFAULT, dpacl);
 	}
 
-out_drop_lock:
+out:
 	fh_unlock(fhp);
-
 	posix_acl_release(pacl);
 	posix_acl_release(dpacl);
-out_nfserr:
+	return host_error;
+}
+
+static int
+convert_ace_to_nfs41(u32 *p, const struct nfs4_ace *ace)
+{
+	int error = 0;
+	nfsace4i nace;
+
+	nace = (nfsace4i) {
+		.type = (acetype4)ace->type,
+		.flag = (aceflag4)ace->flag & NFS41_FLAGS,
+		.access_mask = ace->access_mask & NFS4_ACE_MASK_ALL,
+		.who = -1,
+	};
+
+	/* Audit and Alarm are not currently supported */
+	if (nace.type > NFS4_ACE_ACCESS_DENIED_ACE_TYPE)
+		return -EINVAL;
+
+	switch (ace->whotype) {
+	case NFS4_ACL_WHO_OWNER:
+		nace.iflag = ACEI4_SPECIAL_WHO;
+		nace.who = ACE4_SPECIAL_OWNER;
+		break;
+	case NFS4_ACL_WHO_GROUP:
+		nace.iflag = ACEI4_SPECIAL_WHO;
+		nace.who = ACE4_SPECIAL_GROUP;
+		break;
+	case NFS4_ACL_WHO_EVERYONE:
+		nace.iflag = ACEI4_SPECIAL_WHO;
+		nace.who = ACE4_SPECIAL_EVERYONE;
+		break;
+	case NFS4_ACL_WHO_NAMED:
+		if (ace->flag & NFS4_ACE_IDENTIFIER_GROUP)
+			nace.who = (int)__kgid_val(ace->who_gid);
+		else
+			nace.who = (int)__kuid_val(ace->who_uid);
+
+		BUG_ON(nace.who == -1);
+		break;
+	default:
+		error = -EINVAL;
+		break;
+	}
+
+	*p++ = htonl(nace.type);
+	*p++ = htonl(nace.flag);
+	*p++ = htonl(nace.iflag);
+	*p++ = htonl(nace.access_mask);
+	*p++ = htonl(nace.who);
+
+	return error;
+}
+
+static int
+generate_nfs41acl_buf(u32 *xdrbuf, const struct nfs4_acl *acl)
+{
+	int error = 0;
+	int i;
+
+	/* first byte is NFS41 Flags. Skip since these are RFC3530 acls */
+	*xdrbuf++ = 0;
+	*xdrbuf++ = htonl(acl->naces);
+
+	for (i = 0; i < acl->naces; i++, xdrbuf += NACE41_LEN) {
+		error = convert_ace_to_nfs41(xdrbuf, &acl->aces[i]);
+		if (error)
+			break;
+	}
+
+	return error;
+}
+
+static int
+nfsv4_set_nfsv41xdr_acl(struct svc_fh *fhp, struct nfs4_acl *acl)
+{
+	int error;
+	struct dentry *dentry;
+	u32 *xdr_buf = NULL;
+	size_t len;
+
+	if (acl->naces > NFS41ACL_MAX_ENTRIES)
+		return -ERANGE;
+
+	else if (acl->naces == 0)
+		return -EINVAL;
+
+	dentry = fhp->fh_dentry;
+	len = ACES_TO_XDRSIZE(acl->naces);
+
+	xdr_buf = kzalloc(len, GFP_KERNEL);
+	if (!xdr_buf)
+		return -ENOMEM;
+
+	error = generate_nfs41acl_buf(xdr_buf, acl);
+	if (error) {
+		kfree(xdr_buf);
+		return error;
+	}
+
+	error = vfs_setxattr(dentry, NA41_NAME, xdr_buf, len, XATTR_REPLACE);
+	kfree(xdr_buf);
+	return error;
+}
+
+static inline int
+nfs4_acl_nfsv4_set_native(struct svc_fh *fhp, struct nfs4_acl *acl)
+{
+	struct inode *inode = d_inode(fhp->fh_dentry);
+
+	if (IS_NFSV4ACL(inode))
+		return nfsv4_set_nfsv41xdr_acl(fhp, acl);
+	else
+		return nfsv4_set_posix_acl(fhp, acl);
+}
+
+__be32
+nfsd4_set_nfs4_acl(struct svc_rqst *rqstp, struct svc_fh *fhp,
+		struct nfs4_acl *acl)
+{
+	__be32 error;
+	int host_error;
+
+	error = fh_verify(rqstp, fhp, 0, NFSD_MAY_SATTR);
+	if (error)
+		return error;
+
+	host_error = nfs4_acl_nfsv4_set_native(fhp, acl);
 	if (host_error == -EOPNOTSUPP)
 		return nfserr_attrnotsupp;
 	else

--- a/fs/nfsd/nfs4proc.c
+++ b/fs/nfsd/nfs4proc.c
@@ -103,7 +103,8 @@ check_attr_support(struct svc_rqst *rqstp, struct nfsd4_compound_state *cstate,
 
 	if (!nfsd_attrs_supported(cstate->minorversion, bmval))
 		return nfserr_attrnotsupp;
-	if ((bmval[0] & FATTR4_WORD0_ACL) && !IS_POSIXACL(d_inode(dentry)))
+	if ((bmval[0] & FATTR4_WORD0_ACL) && !IS_POSIXACL(d_inode(dentry)) &&
+	    !IS_NFSV4ACL(d_inode(dentry)))
 		return nfserr_attrnotsupp;
 	if ((bmval[2] & FATTR4_WORD2_SECURITY_LABEL) &&
 			!(exp->ex_flags & NFSEXP_SECURITY_LABEL))

--- a/fs/nfsd/nfs4xdr.c
+++ b/fs/nfsd/nfs4xdr.c
@@ -2804,7 +2804,8 @@ nfsd4_encode_fattr(struct xdr_stream *xdr, struct svc_fh *fhp,
 
 		memcpy(supp, nfsd_suppattrs[minorversion], sizeof(supp));
 
-		if (!IS_POSIXACL(dentry->d_inode))
+		if (!IS_POSIXACL(dentry->d_inode) &&
+		    !IS_NFSV4ACL(dentry->d_inode))
 			supp[0] &= ~FATTR4_WORD0_ACL;
 		if (!contextsupport)
 			supp[2] &= ~FATTR4_WORD2_SECURITY_LABEL;
@@ -2952,7 +2953,7 @@ out_acl:
 		p = xdr_reserve_space(xdr, 4);
 		if (!p)
 			goto out_resource;
-		*p++ = cpu_to_be32(IS_POSIXACL(dentry->d_inode) ?
+		*p++ = cpu_to_be32(IS_POSIXACL(dentry->d_inode) || IS_NFSV4ACL(dentry->d_inode) ?
 			ACL4_SUPPORT_ALLOW_ACL|ACL4_SUPPORT_DENY_ACL : 0);
 	}
 	if (bmval0 & FATTR4_WORD0_CANSETTIME) {

--- a/fs/nfsd/vfs.c
+++ b/fs/nfsd/vfs.c
@@ -1252,7 +1252,7 @@ nfsd_create_locked(struct svc_rqst *rqstp, struct svc_fh *fhp,
 		iap->ia_mode = 0;
 	iap->ia_mode = (iap->ia_mode & S_IALLUGO) | type;
 
-	if (!IS_POSIXACL(dirp))
+	if (!IS_POSIXACL(dirp) && !IS_NFSV4ACL(dirp))
 		iap->ia_mode &= ~current_umask();
 
 	err = 0;
@@ -1487,7 +1487,7 @@ do_nfsd_create(struct svc_rqst *rqstp, struct svc_fh *fhp,
 		goto out;
 	}
 
-	if (!IS_POSIXACL(dirp))
+	if (!IS_POSIXACL(dirp) && !IS_NFSV4ACL(dirp))
 		iap->ia_mode &= ~current_umask();
 
 	host_err = vfs_create(dirp, dchild, iap->ia_mode, true);
@@ -2395,6 +2395,20 @@ nfsd_permission(struct svc_rqst *rqstp, struct svc_export *exp,
 
 	/* This assumes  NFSD_MAY_{READ,WRITE,EXEC} == MAY_{READ,WRITE,EXEC} */
 	err = inode_permission(inode, acc & (MAY_READ|MAY_WRITE|MAY_EXEC));
+
+	/*
+	 * See RFC 5661 Section 6.2.1.3.2
+	 * Allow NFSv4 ACL to override normal delete permission
+	 * In this case REMOVE is granted if DELETE is granted on file
+	 * or DELETE_CHILD is granted on parent.
+	 */
+	if ((err == -EACCES) && IS_NFSV4ACL(inode) &&
+	    (acc == NFSD_MAY_REMOVE)) {
+		err = inode_permission(inode, MAY_DELETE);
+		if (err == -EACCES)
+			err = inode_permission(d_inode(dentry->d_parent),
+			    MAY_DELETE_CHILD);
+	}
 
 	/* Allow read access to binaries even when mode 111 */
 	if (err == -EACCES && S_ISREG(inode->i_mode) &&


### PR DESCRIPTION
ZFS currently exposes native ZFS nfsv4 ACL type through
the system.nfs4_acl_xdr xattr. underlying ACL type can
be determined via inode sb flags (previous kernel work).

This PR makes the Kernel NFS server aware of this ACL
type and has it read from and write to the xattr is
the relevant NFS40 ops.

At this point only NFS40 ACLs are implemented (RFC3530)
because they are currently only ones supported by the
Kernel NFS client in Linux.

ACE_INHERITED_ACE is returned in request for NFS40 ACL.
This is for consistency with FreeBSD behavior, and is
important for SMB / NFS compatibility. At a future
point in time, full NFS41 ACL compatibility will
most likely be required (for feature parity with
other commercial vendors). nfs4-acl-tools version 0.3.3
and earlier contains a bug where the persence of
ACE_INHERITED_ACE is mistakenly identified as making
ACE apply to the file owner.

Signed-off-by: Andrew Walker <awalker@ixsystems.com>