### PR TITLE
NAS-116379 / 22.02.2 / ntb_hw_plx: Fix incorrect BUG_ON()

### DIFF
--- a/drivers/ntb/hw/plx/ntb_hw_plx.c
+++ b/drivers/ntb/hw/plx/ntb_hw_plx.c
@@ -335,7 +335,7 @@ static int plx_ntb_peer_mw_get_addr(struct ntb_dev *ntb, int idx, phys_addr_t *b
 	offset = 0;
 	if (idx == ndev->b2b_mw) {
 		/* User should not get non-shared B2B MW */
-		BUG_ON(ndev->b2b_off != 0);
+		BUG_ON(ndev->b2b_off == 0);
 		offset = ndev->b2b_off;
 	}
 	mw = &ndev->mw_info[idx];


### PR DESCRIPTION
Ported from FreeBSD's KASSERT() it got condition inverted.

Ticket:	NAS-116379
(cherry picked from commit 9562e3afcfc662f9022192771f2f441977e8b846)