### PR TITLE
NAS-111045 / None / Allow concurrent skipping for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         id: skip_check
         uses: fkirc/skip-duplicate-actions@v3.4.1
         with:
-          skip_after_successful_duplicate: 'true'
+          concurrent_skipping: 'same_content_newer'
 
   build_kernel:
 


### PR DESCRIPTION
Currently, the CI run for Pull Requests are skipped only if a
successful Push CI run is found. This implies that Push CI run has to
complete before Pull Request should be opened, otherwise Pull Request
CI will also start in parallel to Push CI run.

If upon opening a Pull Request, a Push CI run is already in progress,
concurrent skipping allows to skip Pull Request CI run completely.

'same_content_newer' ensures that atleast one of Push or Pull Request
is run. If a new commit is added after opening a Pull Request or in
case of force push, atleast one of Pull Request or Push CI run will
be performed.

Signed-off-by: Umer Saleem <usaleem@ixsystems.com>