### PR TITLE
NAS-118913 / None / Add DMA support to NVDIMM pmem driver.

### DIFF
--- a/drivers/nvdimm/pmem.h
+++ b/drivers/nvdimm/pmem.h
@@ -6,6 +6,7 @@
 #include <linux/types.h>
 #include <linux/pfn_t.h>
 #include <linux/fs.h>
+#include <linux/dmaengine.h>
 
 #define PMEM_SIGN_SHORT	0x4e564430
 #define PMEM_SIGN_LONG	0x4e5644494d4d3030
@@ -50,7 +51,12 @@ struct pmem_device {
 	phys_addr_t		 rphys_addr;	/* Remote PMEM phys address */
 	uint8_t			*rvirt_addr;	/* Remote PMEM KVA address */
 	struct pmem_label	*rlabel;	/* Remote PMEM label */
+	int			 node;		/* Local PMEM NUMA node */
 	int			 rnode;		/* Remote PMEM (NTB) node */
+	int			 opened;	/* Number of device opens */
+	bool			 rdma_for_single; /* Prefer remote DMA */
+	struct dma_chan		*dma_chan;	/* Local PMEM DMA channel */
+	struct dma_chan		*rdma_chan;	/* Remote PMEM DMA channel */
 };
 
 long __pmem_direct_access(struct pmem_device *pmem, pgoff_t pgoff,


### PR DESCRIPTION
Use dmaengine KPI to program I/OAT (or any other engine) to offload memory copies for I/Os above certain size (smaller I/Os are faster in software).  For systems configured for HA synchronization via NTB use second DMA channel to duplicate all writes to remote NVDIMM.

While there, remove redundant loops from software read/write routines. bio_for_each_segment() unlike bio_for_each_bvec() by itself splits all the bio vectors into separate pages.  Assert it just in case.