### PR TITLE
NAS-119705 / None / Disable default enablement of init_on_alloc feature

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -72,3 +72,10 @@ CONFIG_DMA_CMA=y
 # ATA_LPM_UNKNOWN is the default for non-mobile chipsets, aka "max_performance".
 #
 CONFIG_SATA_MOBILE_LPM_POLICY=0
+
+#
+# Disable init_on_alloc to improve ZFS performance. ZFS allocates and frees
+# pages frequently, and init_on_alloc zeroes out the pages during allocation.
+# Disabling init_on_alloc should improve ZFS performance.
+#
+CONFIG_INIT_ON_ALLOC_DEFAULT_ON=n


### PR DESCRIPTION
Disable default init_on_alloc enablement to improve ZFS performance.
ZFS allocates and frees pages frequently, and init_on_alloc zeroes out
the pages during allocation. Disabling init_on_alloc should improve ZFS
performance.
