### PR TITLE
NAS-119337 / 23.10 / Add ALUA support for iSCSI in SCALE

### DIFF
--- a/drivers/scsi/iscsi_tcp.c
+++ b/drivers/scsi/iscsi_tcp.c
@@ -62,6 +62,11 @@ module_param_named(debug_iscsi_tcp, iscsi_sw_tcp_dbg, int,
 MODULE_PARM_DESC(debug_iscsi_tcp, "Turn on debugging for iscsi_tcp module "
 		 "Set to 1 to turn on, and zero to turn off. Default is off.");
 
+#ifdef CONFIG_TRUENAS
+#define HA_PRIVATE_CHANNEL_CONTROLLER_A_IP "169.254.10.1"
+#define HA_PRIVATE_CHANNEL_CONTROLLER_B_IP "169.254.10.2"
+#endif
+
 #define ISCSI_SW_TCP_DBG(_conn, dbg_fmt, arg...)		\
 	do {							\
 		if (iscsi_sw_tcp_dbg)				\
@@ -1051,11 +1056,13 @@ static int iscsi_sw_tcp_slave_configure(struct scsi_device *sdev)
 	struct iscsi_session *session = tcp_sw_host->session;
 	struct iscsi_conn *conn = session->leadconn;
 
+#ifdef CONFIG_TRUENAS
 	if (conn && conn->persistent_address) {
-		if ((strcmp(conn->persistent_address, "169.254.10.1") == 0) ||
-		    (strcmp(conn->persistent_address, "169.254.10.2") == 0))
+		if ((strcmp(conn->persistent_address, HA_PRIVATE_CHANNEL_CONTROLLER_A_IP) == 0) ||
+		    (strcmp(conn->persistent_address, HA_PRIVATE_CHANNEL_CONTROLLER_B_IP) == 0))
 			sdev->genhd_hidden = 1;
 	}
+#endif
 
 	if (conn->datadgst_en)
 		blk_queue_flag_set(QUEUE_FLAG_STABLE_WRITES,

--- a/drivers/scsi/iscsi_tcp.c
+++ b/drivers/scsi/iscsi_tcp.c
@@ -1051,6 +1051,12 @@ static int iscsi_sw_tcp_slave_configure(struct scsi_device *sdev)
 	struct iscsi_session *session = tcp_sw_host->session;
 	struct iscsi_conn *conn = session->leadconn;
 
+	if (conn && conn->persistent_address) {
+		if ((strcmp(conn->persistent_address, "169.254.10.1") == 0) ||
+		    (strcmp(conn->persistent_address, "169.254.10.2") == 0))
+			sdev->genhd_hidden = 1;
+	}
+
 	if (conn->datadgst_en)
 		blk_queue_flag_set(QUEUE_FLAG_STABLE_WRITES,
 				   sdev->request_queue);

--- a/drivers/scsi/sd.c
+++ b/drivers/scsi/sd.c
@@ -3452,8 +3452,10 @@ static int sd_probe(struct device *dev)
 		gd->events |= DISK_EVENT_MEDIA_CHANGE;
 		gd->event_flags = DISK_EVENT_FLAG_POLL | DISK_EVENT_FLAG_UEVENT;
 	}
+#ifdef CONFIG_TRUENAS
 	if (sdp->genhd_hidden)
 		gd->flags |= GENHD_FL_HIDDEN;
+#endif
 
 	blk_pm_runtime_init(sdp->request_queue, dev);
 	if (sdp->rpm_autosuspend) {

--- a/drivers/scsi/sd.c
+++ b/drivers/scsi/sd.c
@@ -3452,6 +3452,8 @@ static int sd_probe(struct device *dev)
 		gd->events |= DISK_EVENT_MEDIA_CHANGE;
 		gd->event_flags = DISK_EVENT_FLAG_POLL | DISK_EVENT_FLAG_UEVENT;
 	}
+	if (sdp->genhd_hidden)
+		gd->flags |= GENHD_FL_HIDDEN;
 
 	blk_pm_runtime_init(sdp->request_queue, dev);
 	if (sdp->rpm_autosuspend) {

--- a/include/scsi/scsi_device.h
+++ b/include/scsi/scsi_device.h
@@ -207,7 +207,9 @@ struct scsi_device {
 					 * creation time */
 	unsigned ignore_media_change:1; /* Ignore MEDIA CHANGE on resume */
 	unsigned silence_suspend:1;	/* Do not print runtime PM related messages */
+#ifdef CONFIG_TRUENAS
 	unsigned genhd_hidden:1;	/* Set GENHD_FL_HIDDEN flag when creating gendisk */
+#endif
 
 	bool offline_already;		/* Device offline message logged */
 

--- a/include/scsi/scsi_device.h
+++ b/include/scsi/scsi_device.h
@@ -207,6 +207,7 @@ struct scsi_device {
 					 * creation time */
 	unsigned ignore_media_change:1; /* Ignore MEDIA CHANGE on resume */
 	unsigned silence_suspend:1;	/* Do not print runtime PM related messages */
+	unsigned genhd_hidden:1;	/* Set GENHD_FL_HIDDEN flag when creating gendisk */
 
 	bool offline_already;		/* Device offline message logged */
 


### PR DESCRIPTION
For our HA iSCSI ALUA support we are currently planning to login to Active controller iSCSI targets from the Standby controller before reexporting the targets from the Standby controller (albeit flagged as Non-Optimized).

Using regular tools to do this saves code & development effort, but one downside was that the targets would surface and be exposed as SCSI disks on the Standby node, not really something that we desire.  Therefore, see the two commits in this PR to avoid the situation.

1. Add `genhd_hidden` flag
This is a **generic** mechanism whereby a LLD can request that the `GENHD_FL_HIDDEN` flag be set on the created gendisk.  Hidden gendisk support was [previously](https://github.com/truenas/linux/commit/8ddcd653257c18a669fcb75ee42c37054908e0d6) added to the kernel in 2017, and [used](https://github.com/truenas/linux/commit/32acab3181c7053c775ca128c3a5c6ce50197d7f) for nvme multipath.  (Refactored many times since, but still used today, e.g. kernel [6.1.11](https://elixir.bootlin.com/linux/v6.1.11/A/ident/GENHD_FL_HIDDEN))
2. Hide logged-in HA peer node iSCSI targets from local access
This is TrueNAS specific & relies on the IP addresses used on the HA private channel.

