### PR TITLE
NAS-120078 / None / Add support to periodically poll enclosures

### DIFF
--- a/include/linux/enclosure.h
+++ b/include/linux/enclosure.h
@@ -100,6 +100,8 @@ struct enclosure_device {
 	struct list_head node;
 	struct device edev;
 	struct enclosure_component_callbacks *cb;
+	struct task_struct *poll_task;
+	spinlock_t enc_lock;
 	int components;
 	struct enclosure_component component[];
 };


### PR DESCRIPTION
SES device of the enclosure reports disk's SAS address in Additional Element Status few seconds after disk is detected by SES driver. The periodic polling of enclosures allows enclosure to be added in case of the lost events.