### PR TITLE
NAS-120160 / 22.12.2 / Disable default restriction to access IO memory from /dev/mem

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -72,3 +72,10 @@ CONFIG_DMA_CMA=y
 # ATA_LPM_UNKNOWN is the default for non-mobile chipsets, aka "max_performance".
 #
 CONFIG_SATA_MOBILE_LPM_POLICY=0
+
+#
+# Allow userspace (root) access to all IO memory. /dev/mem allows
+# userspace access to memory ranges that may or may not be actively
+# used by a driver. Required for plx_eeprom utility.
+#
+CONFIG_IO_STRICT_DEVMEM=n


### PR DESCRIPTION
Allow userspace (root) access to all IO memory. /dev/mem allows userspace access to memory ranges that may or may not be actively used by a driver. Required for plx_eeprom utility.