### PR TITLE
NAS-120160 / None / Disable default restriction to access IO memory from /dev/mem

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -79,3 +79,10 @@ CONFIG_SATA_MOBILE_LPM_POLICY=0
 # Disabling init_on_alloc should improve ZFS performance.
 #
 CONFIG_INIT_ON_ALLOC_DEFAULT_ON=n
+
+#
+# Allow userspace (root) access to all IO memory. /dev/mem allows
+# userspace access to memory ranges that may or may not be actively
+# used by a driver. Required for plx_eeprom utility.
+#
+CONFIG_IO_STRICT_DEVMEM=n


### PR DESCRIPTION
Allow userspace (root) access to all IO memory. /dev/mem allows userspace access to memory rabges that may or may not be actively by a driver. Required for plx_eeprom utility.