### PR TITLE
NAS-121174 / 22.12.3 / [stable/bluefin] ixgbe: Print fw warning message only once

### DIFF
--- a/drivers/net/ethernet/intel/ixgbe/ixgbe.h
+++ b/drivers/net/ethernet/intel/ixgbe/ixgbe.h
@@ -687,6 +687,7 @@ struct ixgbe_adapter {
 	bool link_up;
 	unsigned long sfp_poll_time;
 	unsigned long link_check_timeout;
+	bool fw_error_msg;
 
 	struct timer_list service_timer;
 	struct work_struct service_task;

--- a/drivers/net/ethernet/intel/ixgbe/ixgbe_main.c
+++ b/drivers/net/ethernet/intel/ixgbe/ixgbe_main.c
@@ -7892,10 +7892,12 @@ static bool ixgbe_check_fw_error(struct ixgbe_adapter *adapter)
 	/* read fwsm.ext_err_ind register and log errors */
 	fwsm = IXGBE_READ_REG(hw, IXGBE_FWSM(hw));
 
-	if (fwsm & IXGBE_FWSM_EXT_ERR_IND_MASK ||
-	    !(fwsm & IXGBE_FWSM_FW_VAL_BIT))
+	if (!adapter->fw_error_msg && (fwsm & IXGBE_FWSM_EXT_ERR_IND_MASK ||
+	    !(fwsm & IXGBE_FWSM_FW_VAL_BIT))) {
+		adapter->fw_error_msg = true;
 		e_dev_warn("Warning firmware error detected FWSM: 0x%08X\n",
 			   fwsm);
+	}
 
 	if (hw->mac.ops.fw_recovery_mode && hw->mac.ops.fw_recovery_mode(hw)) {
 		e_dev_err("Firmware recovery mode detected. Limiting functionality. Refer to the Intel(R) Ethernet Adapters and Devices User Guide for details on firmware recovery mode.\n");


### PR DESCRIPTION
If FW_VAL_BIT is set to 0, a warning message is logged every second in an ixgbe_service_task(), making the TrueNAS console unusable. Some users still face the issue after updating to the latest Intel firmware without noticing any performance issue in NIC. In the case of this scenario, we should only log the warning message once. This should still bring attention to the user and does not spam the logs.