### PR TITLE
NAS-120951 / None / Enable APEI/GHES BIOS error detection via EDAC

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -127,3 +127,8 @@ CONFIG_MEMSTICK=n
 # Disable SoundWire
 #
 CONFIG_SOUNDWIRE=n
+
+#
+# Enable APEI/GHES BIOS error detection via EDAC
+#
+CONFIG_EDAC_GHES=y


### PR DESCRIPTION
EDAC supports error reporting from MCA and APEI/GHES. CONFIG_EDAC_GHES was disabled from Debian config so it is being enabled from truenas.config.