### PR TITLE
NAS-120951 / 22.12.3 / Enable APEI/GHES BIOS error detection via EDAC

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -79,3 +79,8 @@ CONFIG_SATA_MOBILE_LPM_POLICY=0
 # used by a driver. Required for plx_eeprom utility.
 #
 CONFIG_IO_STRICT_DEVMEM=n
+
+#
+# Enable APEI/GHES BIOS error detection via EDAC
+#
+CONFIG_EDAC_GHES=y


### PR DESCRIPTION
EDAC supports error reporting from MCA and APEI/GHES. CONFIG_EDAC_GHES was disabled from Debian config so it is being enabled from truenas.config.