### PR TITLE
NAS-121761 / Implement native NFSv4 ACLs in NFS server

### DIFF
--- a/fs/nfsd/acl.h
+++ b/fs/nfsd/acl.h
@@ -45,9 +45,10 @@ int nfs4_acl_bytes(int entries);
 int nfs4_acl_get_whotype(char *, u32);
 __be32 nfs4_acl_write_who(struct xdr_stream *xdr, int who);
 
+void nfsd4_setup_attr(struct dentry *dentry, struct nfsd_attrs *attr);
 int nfsd4_get_nfs4_acl(struct svc_rqst *rqstp, struct dentry *dentry,
 		struct nfs4_acl **acl);
-__be32 nfsd4_acl_to_attr(enum nfs_ftype4 type, struct nfs4_acl *acl,
-			 struct nfsd_attrs *attr);
+int nfsv4_set_zfacl_from_attr(struct dentry *dentry,
+		struct nfsd_attrs *attr);
 
 #endif /* LINUX_NFS4_ACL_H */

--- a/fs/nfsd/nfs3proc.c
+++ b/fs/nfsd/nfs3proc.c
@@ -316,7 +316,7 @@ nfsd3_create_file(struct svc_rqst *rqstp, struct svc_fh *fhp,
 		goto out;
 	}
 
-	if (!IS_POSIXACL(inode))
+	if (!IS_POSIXACL(inode) && !IS_NFSV4ACL(inode))
 		iap->ia_mode &= ~current_umask();
 
 	fh_fill_pre_attrs(fhp);

--- a/fs/nfsd/nfs41acl_xdr.h
+++ b/fs/nfsd/nfs41acl_xdr.h
@@ -1,0 +1,61 @@
+#ifndef _NFS41ACL_H_RPCGEN
+#define _NFS41ACL_H_RPCGEN
+
+#define NA41_NAME "system.nfs4_acl_xdr"
+
+typedef u_int acetype4;
+#define ACE4_FILE_INHERIT_ACE 0x00000001
+#define ACE4_DIRECTORY_INHERIT_ACE 0x00000002
+#define ACE4_NO_PROPAGATE_INHERIT_ACE 0x00000004
+#define ACE4_INHERIT_ONLY_ACE 0x00000008
+#define ACE4_SUCCESSFUL_ACCESS_ACE_FLAG 0x00000010
+#define ACE4_FAILED_ACCESS_ACE_FLAG 0x00000020
+#define ACE4_IDENTIFIER_GROUP 0x00000040
+#define ACE4_INHERITED_ACE 0x00000080
+#define NFS41_FLAGS	(ACE4_DIRECTORY_INHERIT_ACE| \
+			 ACE4_FILE_INHERIT_ACE| \
+			 ACE4_NO_PROPAGATE_INHERIT_ACE| \
+			 ACE4_INHERIT_ONLY_ACE| \
+			 ACE4_INHERITED_ACE| \
+			 ACE4_IDENTIFIER_GROUP)
+
+typedef u_int aceflag4;
+#define ACEI4_SPECIAL_WHO 0x00000001
+
+typedef u_int aceiflag4;
+#define ACE4_SPECIAL_OWNER 1
+#define ACE4_SPECIAL_GROUP 2
+#define ACE4_SPECIAL_EVERYONE 3
+
+typedef u_int acemask4;
+
+struct nfsace4i {
+	acetype4 type;
+	aceflag4 flag;
+	aceiflag4 iflag;
+	acemask4 access_mask;
+	u_int who;
+};
+typedef struct nfsace4i nfsace4i;
+#define NACE41_LEN 5
+#define ACL4_AUTO_INHERIT 0x00000001
+#define ACL4_PROTECTED 0x00000002
+#define ACL4_DEFAULTED 0x00000004
+
+typedef u_int aclflag4;
+
+/*
+ * Macros for sanity checks related to XDR and ACL buffer sizes
+ */
+#define NFS41ACL_MAX_ENTRIES	128
+#define ACE4SIZE                (sizeof (nfsace4i))
+#define XDRBASE                 (2 * sizeof (u32))
+
+#define ACES_TO_SIZE(x, y)      (x + (y * ACE4SIZE))
+#define SIZE_IS_VALID(x, y)     ((x >= ACES_TO_SIZE(y, 0)) && \
+                                (((x - y) % ACE4SIZE) == 0))
+
+#define ACES_TO_XDRSIZE(x)      (ACES_TO_SIZE(XDRBASE, x))
+#define XDRSIZE_IS_VALID(x)     (SIZE_IS_VALID(x, XDRBASE))
+
+#endif /* !_NFS41ACL_H_RPCGEN */

--- a/fs/nfsd/nfs41acl_xdr.h
+++ b/fs/nfsd/nfs41acl_xdr.h
@@ -3,7 +3,6 @@
 
 #define NA41_NAME "system.nfs4_acl_xdr"
 
-typedef u_int acetype4;
 #define ACE4_FILE_INHERIT_ACE 0x00000001
 #define ACE4_DIRECTORY_INHERIT_ACE 0x00000002
 #define ACE4_NO_PROPAGATE_INHERIT_ACE 0x00000004
@@ -19,36 +18,21 @@ typedef u_int acetype4;
 			 ACE4_INHERITED_ACE| \
 			 ACE4_IDENTIFIER_GROUP)
 
-typedef u_int aceflag4;
 #define ACEI4_SPECIAL_WHO 0x00000001
-
-typedef u_int aceiflag4;
 #define ACE4_SPECIAL_OWNER 1
 #define ACE4_SPECIAL_GROUP 2
 #define ACE4_SPECIAL_EVERYONE 3
-
-typedef u_int acemask4;
-
-struct nfsace4i {
-	acetype4 type;
-	aceflag4 flag;
-	aceiflag4 iflag;
-	acemask4 access_mask;
-	u_int who;
-};
-typedef struct nfsace4i nfsace4i;
 #define NACE41_LEN 5
+
 #define ACL4_AUTO_INHERIT 0x00000001
 #define ACL4_PROTECTED 0x00000002
 #define ACL4_DEFAULTED 0x00000004
-
-typedef u_int aclflag4;
 
 /*
  * Macros for sanity checks related to XDR and ACL buffer sizes
  */
 #define NFS41ACL_MAX_ENTRIES	128
-#define ACE4SIZE                (sizeof (nfsace4i))
+#define ACE4SIZE                (NACE41_LEN * sizeof(u32))
 #define XDRBASE                 (2 * sizeof (u32))
 
 #define ACES_TO_SIZE(x, y)      (x + (y * ACE4SIZE))

--- a/fs/nfsd/nfs41acl_xdr.h
+++ b/fs/nfsd/nfs41acl_xdr.h
@@ -1,6 +1,28 @@
 #ifndef _NFS41ACL_H_RPCGEN
 #define _NFS41ACL_H_RPCGEN
 
+/*
+ * Native ZFS NFSv41-style ACL is packed in xattr as
+ * follows:
+ *
+ * struct nfsace4i {
+ *    uint32_t type; RFC 5661 Section 6.2.1.1
+ *    uint32_t flag; RFC 5661 Section 6.2.1.4
+ *    uint32_t iflag;
+ *    uint32_t access_mask; RFC 5661 Section 6.2.1.3
+ *    uint32_t who_id;
+ * };
+ *
+ * struct nfsacl4 {
+ *     uint32_t acl_flags; RFC 5661 Section 6.4.3.2
+ *     uint32_t ace_count;
+ *     struct nfsace4i aces<>;
+ * };
+ *
+ * iflag and who_id combined are sufficent for NFS server to convert into ACE
+ * who (RFC 5661 Section 6.2.1.5).
+ */
+
 #define NA41_NAME "system.nfs4_acl_xdr"
 
 #define ACE4_FILE_INHERIT_ACE 0x00000001

--- a/fs/nfsd/nfs4acl.c
+++ b/fs/nfsd/nfs4acl.c
@@ -37,11 +37,13 @@
 #include <linux/fs.h>
 #include <linux/slab.h>
 #include <linux/posix_acl.h>
+#include <linux/xattr.h>
 
 #include "nfsfh.h"
 #include "nfsd.h"
 #include "acl.h"
 #include "vfs.h"
+#include "nfs41acl_xdr.h"
 
 #define NFS4_ACL_TYPE_DEFAULT	0x01
 #define NFS4_ACL_DIR		0x02
@@ -125,8 +127,8 @@ static short ace2type(struct nfs4_ace *);
 static void _posix_to_nfsv4_one(struct posix_acl *, struct nfs4_acl *,
 				unsigned int);
 
-int
-nfsd4_get_nfs4_acl(struct svc_rqst *rqstp, struct dentry *dentry,
+static int
+get_nfs4_posix_acl(struct svc_rqst *rqstp, struct dentry *dentry,
 		struct nfs4_acl **acl)
 {
 	struct inode *inode = d_inode(dentry);
@@ -174,6 +176,159 @@ out:
 rel_pacl:
 	posix_acl_release(pacl);
 	return error;
+}
+
+static int
+convert_to_nfs40_ace(u32 *xdrbuf, struct nfs4_ace *ace)
+{
+	int error = 0;
+	u32 iflag, id;
+
+	ace->type = ntohl(*(xdrbuf++));
+	if (ace->type > NFS4_ACE_ACCESS_DENIED_ACE_TYPE)
+		return -EINVAL;
+
+	ace->flag = ntohl(*(xdrbuf++));
+	iflag = ntohl(*(xdrbuf++));
+	ace->access_mask = ntohl(*(xdrbuf++)) & NFS4_ACE_MASK_ALL;
+	id = ntohl(*(xdrbuf++));
+
+	if (iflag & ACEI4_SPECIAL_WHO) {
+		switch(id) {
+		case ACE4_SPECIAL_OWNER:
+			ace->whotype = NFS4_ACL_WHO_OWNER;
+			break;
+		case ACE4_SPECIAL_GROUP:
+			ace->whotype = NFS4_ACL_WHO_GROUP;
+			break;
+		case ACE4_SPECIAL_EVERYONE:
+			ace->whotype = NFS4_ACL_WHO_EVERYONE;
+			break;
+		}
+	} else {
+		ace->whotype = NFS4_ACL_WHO_NAMED;
+		if (ace->flag & NFS4_ACE_IDENTIFIER_GROUP) {
+			ace->who_gid = make_kgid(&init_user_ns, id);
+			if (!gid_valid(ace->who_gid)) {
+				error = -EINVAL;
+			}
+		} else {
+			ace->who_uid = make_kuid(&init_user_ns, id);
+			if (!uid_valid(ace->who_uid)) {
+				error = -EINVAL;
+			}
+		}
+	}
+
+	return error;
+}
+
+static int
+convert_nfs41xdr_to_nfs40_acl(u32 *xdrbuf, size_t remaining, struct nfs4_acl *acl)
+{
+	int error = 0;
+	int i;
+
+	for (i = 0; i < acl->naces; i++, xdrbuf += NACE41_LEN) {
+		if (remaining < (NACE41_LEN * sizeof(u32))) {
+			error = -EOVERFLOW;
+			break;
+		}
+
+		error = convert_to_nfs40_ace(xdrbuf, &acl->aces[i]);
+		if (error)
+			break;
+
+		remaining -= (NACE41_LEN * sizeof(u32));
+	}
+
+	BUG_ON(remaining != 0);
+	return error;
+}
+
+static int
+get_nfs4_nfsv41xdr_acl(struct svc_rqst *rqstp, struct dentry *dentry,
+		struct nfs4_acl **pacl)
+{
+	int error = 0;
+	u32 ace_cnt;
+	u32 *xdr_buf = NULL, *p;
+	struct nfs4_acl *acl = NULL;
+	ssize_t len;
+	size_t xdr_buf_sz = ACES_TO_XDRSIZE(NFS41ACL_MAX_ENTRIES);
+
+	xdr_buf = kzalloc(xdr_buf_sz, GFP_KERNEL);
+	if (!xdr_buf)
+		return -ENOMEM;
+
+	len = vfs_getxattr(&init_user_ns, dentry, NA41_NAME, xdr_buf, xdr_buf_sz);
+	if (len == 0)
+		return -EOPNOTSUPP;
+
+	if (len < 0) {
+		switch (len) {
+		case -EOPNOTSUPP:
+			/* ZFS says NFSv4 ACLs not supported */
+			error = -EOPNOTSUPP;
+			goto out;
+		case -EINVAL:
+			/* ZFS unhappy with buffer size */
+			error = -EINVAL;
+			goto out;
+		case -ERANGE:
+			/* our buffer is too small. This is _very_ unexpected */
+			error = -EINVAL;
+			goto out;
+		case -EPERM:
+		case -EACCES:
+			error = -EPERM;
+			goto out;
+		default:
+			error = -ENOMEM;
+			goto out;
+		}
+	}
+
+	BUG_ON(!(XDRSIZE_IS_VALID(len)));
+
+	/*
+	 * skip first byte since it contains ACL flags that
+	 * aren't used in NFSv4.0 ACLs
+	 */
+	p = xdr_buf + 1;
+	ace_cnt = ntohl(*(p++));
+	if (ace_cnt > NFS41ACL_MAX_ENTRIES) {
+		error = -ERANGE;
+		goto out;
+	}
+
+	acl = kzalloc(nfs4_acl_bytes(ace_cnt), GFP_KERNEL);
+	if (!acl) {
+		error = -ENOMEM;
+		goto out;
+	}
+	acl->naces = ace_cnt;
+
+	error = convert_nfs41xdr_to_nfs40_acl(p++, len - (2 * sizeof(u32)), acl);
+	if (error)
+		kfree(acl);
+	else
+		*pacl = acl;
+out:
+	kfree(xdr_buf);
+	return (error);
+}
+
+int
+nfsd4_get_nfs4_acl(struct svc_rqst *rqstp, struct dentry *dentry,
+		struct nfs4_acl **acl)
+{
+	struct inode *inode = d_inode(dentry);
+
+	if (IS_NFSV4ACL(inode))
+		return get_nfs4_nfsv41xdr_acl(rqstp, dentry, acl);
+	else
+		return get_nfs4_posix_acl(rqstp, dentry, acl);
 }
 
 struct posix_acl_summary {
@@ -751,24 +906,159 @@ out_estate:
 	return ret;
 }
 
-__be32 nfsd4_acl_to_attr(enum nfs_ftype4 type, struct nfs4_acl *acl,
-			 struct nfsd_attrs *attr)
+static __be32
+nfsd4_acl_to_attr_posix(enum nfs_ftype4 type, struct nfs4_acl *acl,
+			fsacl_t *fsaclp)
 {
 	int host_error;
 	unsigned int flags = 0;
 
 	if (!acl)
 		return nfs_ok;
-
 	if (type == NF4DIR)
 		flags = NFS4_ACL_DIR;
 
-	host_error = nfs4_acl_nfsv4_to_posix(acl, &attr->na_pacl,
-					     &attr->na_dpacl, flags);
+	host_error = nfs4_acl_nfsv4_to_posix(acl, &fsaclp->posixacl.na_pacl,
+					     &fsaclp->posixacl.na_dpacl, flags);
 	if (host_error == -EINVAL)
 		return nfserr_attrnotsupp;
 	else
 		return nfserrno(host_error);
+}
+
+static int
+convert_ace_to_nfs41(u32 *p, const struct nfs4_ace *ace)
+{
+	int error = 0;
+	nfsace4i nace;
+
+	nace = (nfsace4i) {
+		.type = (acetype4)ace->type,
+		.flag = (aceflag4)ace->flag & NFS41_FLAGS,
+		.access_mask = ace->access_mask & NFS4_ACE_MASK_ALL,
+		.who = -1,
+	};
+
+	/* Audit and Alarm are not currently supported */
+	if (nace.type > NFS4_ACE_ACCESS_DENIED_ACE_TYPE)
+		return -EINVAL;
+
+	switch (ace->whotype) {
+	case NFS4_ACL_WHO_OWNER:
+		nace.iflag = ACEI4_SPECIAL_WHO;
+		nace.who = ACE4_SPECIAL_OWNER;
+		break;
+	case NFS4_ACL_WHO_GROUP:
+		nace.iflag = ACEI4_SPECIAL_WHO;
+		nace.who = ACE4_SPECIAL_GROUP;
+		break;
+	case NFS4_ACL_WHO_EVERYONE:
+		nace.iflag = ACEI4_SPECIAL_WHO;
+		nace.who = ACE4_SPECIAL_EVERYONE;
+		break;
+	case NFS4_ACL_WHO_NAMED:
+		if (ace->flag & NFS4_ACE_IDENTIFIER_GROUP)
+			nace.who = (int)__kgid_val(ace->who_gid);
+		else
+			nace.who = (int)__kuid_val(ace->who_uid);
+
+		BUG_ON(nace.who == -1);
+		break;
+	default:
+		error = -EINVAL;
+		break;
+	}
+
+	*p++ = htonl(nace.type);
+	*p++ = htonl(nace.flag);
+	*p++ = htonl(nace.iflag);
+	*p++ = htonl(nace.access_mask);
+	*p++ = htonl(nace.who);
+
+	return error;
+}
+
+static int
+generate_nfs41acl_buf(u32 *xdrbuf, const struct nfs4_acl *acl)
+{
+	int error = 0;
+	int i;
+
+	/* first byte is NFS41 Flags. Skip since these are RFC3530 acls */
+	*xdrbuf++ = 0;
+	*xdrbuf++ = htonl(acl->naces);
+
+	for (i = 0; i < acl->naces; i++, xdrbuf += NACE41_LEN) {
+		error = convert_ace_to_nfs41(xdrbuf, &acl->aces[i]);
+		if (error)
+			break;
+	}
+
+	return error;
+}
+
+static __be32
+nfsd4_acl_to_attr_zfsacl(enum nfs_ftype4 type, struct nfs4_acl *acl,
+			 fsacl_t *fsaclp)
+{
+	int error;
+	u32 *xdr_buf = NULL;
+	size_t len;
+
+	if (!acl)
+		return nfs_ok;
+
+	if (acl->naces > NFS41ACL_MAX_ENTRIES)
+		return nfserrno(-ERANGE);
+
+	else if (acl->naces == 0)
+		return nfserrno(-EINVAL);
+
+	len = ACES_TO_XDRSIZE(acl->naces);
+
+	xdr_buf = kzalloc(len, GFP_KERNEL);
+	if (!xdr_buf)
+		return nfserrno(-ENOMEM);
+
+	error = generate_nfs41acl_buf(xdr_buf, acl);
+	if (error) {
+		kfree(xdr_buf);
+		return nfserrno(error);
+		return error;
+	}
+
+	fsaclp->zfsacl.aclbuf = xdr_buf;
+	fsaclp->zfsacl.sz = len;
+
+	return nfs_ok;
+}
+
+static __be32
+nfsd4_acl_to_attr_fail(enum nfs_ftype4 type, struct nfs4_acl *acl,
+		       fsacl_t *fsaclp)
+{
+	if (!acl)
+		return nfs_ok;
+
+	return nfserr_attrnotsupp;
+}
+
+int
+nfsv4_set_zfacl_from_attr(struct dentry *dentry, struct nfsd_attrs *attr)
+{
+	struct inode *delegated_inode = NULL;
+	int error;
+
+retry:
+	error = __vfs_setxattr_locked(&init_user_ns, dentry, NA41_NAME,
+				      attr->na_fsacl.zfsacl.aclbuf,
+				      attr->na_fsacl.zfsacl.sz,
+				      XATTR_REPLACE, &delegated_inode);
+
+	if (delegated_inode)
+		goto retry;
+
+	return error;
 }
 
 static short
@@ -850,4 +1140,21 @@ __be32 nfs4_acl_write_who(struct xdr_stream *xdr, int who)
 	}
 	WARN_ON_ONCE(1);
 	return nfserr_serverfault;
+}
+
+void
+nfsd4_setup_attr(struct dentry *dentry, struct nfsd_attrs *attr)
+{
+	struct inode *inode = d_inode(dentry);
+
+	if (IS_NFSV4ACL(inode)) {
+		attr->na_acltype = ACL_TYPE_ZFS;
+		attr->na_conv_fn = nfsd4_acl_to_attr_zfsacl;
+	} else if (IS_POSIXACL(inode)) {
+		attr->na_acltype = ACL_TYPE_POSIX;
+		attr->na_conv_fn = nfsd4_acl_to_attr_posix;
+	} else {
+		attr->na_acltype = ACL_TYPE_NONE;
+		attr->na_conv_fn = nfsd4_acl_to_attr_fail;
+	}
 }

--- a/fs/nfsd/nfs4acl.c
+++ b/fs/nfsd/nfs4acl.c
@@ -293,8 +293,9 @@ get_nfs4_nfsv41xdr_acl(struct svc_rqst *rqstp, struct dentry *dentry,
 	BUG_ON(!(XDRSIZE_IS_VALID(len)));
 
 	/*
-	 * skip first byte since it contains ACL flags that
-	 * aren't used in NFSv4.0 ACLs
+	 * At preset only NFS 4.0 (RFC 3530) ACLs are exported by the NFS
+	 * server, and so the ACL-wide flags are ignored when generating the
+	 * internal NFS server ACL.
 	 */
 	p = xdr_buf + 1;
 	ace_cnt = ntohl(*(p++));

--- a/fs/nfsd/nfs4proc.c
+++ b/fs/nfsd/nfs4proc.c
@@ -87,7 +87,8 @@ check_attr_support(struct svc_rqst *rqstp, struct nfsd4_compound_state *cstate,
 
 	if (!nfsd_attrs_supported(cstate->minorversion, bmval))
 		return nfserr_attrnotsupp;
-	if ((bmval[0] & FATTR4_WORD0_ACL) && !IS_POSIXACL(d_inode(dentry)))
+	if ((bmval[0] & FATTR4_WORD0_ACL) && !IS_POSIXACL(d_inode(dentry)) &&
+	    !IS_NFSV4ACL(d_inode(dentry)))
 		return nfserr_attrnotsupp;
 	if ((bmval[2] & FATTR4_WORD2_SECURITY_LABEL) &&
 			!(exp->ex_flags & NFSEXP_SECURITY_LABEL))
@@ -236,6 +237,7 @@ nfsd4_create_file(struct svc_rqst *rqstp, struct svc_fh *fhp,
 	struct nfsd_attrs attrs = {
 		.na_iattr	= iap,
 		.na_seclabel	= &open->op_label,
+		.na_acltype	= ACL_TYPE_NONE
 	};
 	struct dentry *parent, *child;
 	__u32 v_mtime, v_atime;
@@ -258,8 +260,10 @@ nfsd4_create_file(struct svc_rqst *rqstp, struct svc_fh *fhp,
 	if (host_err)
 		return nfserrno(host_err);
 
-	if (is_create_with_attrs(open))
-		nfsd4_acl_to_attr(NF4REG, open->op_acl, &attrs);
+	if (is_create_with_attrs(open)) {
+		nfsd4_setup_attr(parent, &attrs);
+		attrs.na_conv_fn(NF4REG, open->op_acl, &attrs.na_fsacl);
+	}
 
 	inode_lock_nested(inode, I_MUTEX_PARENT);
 
@@ -754,6 +758,7 @@ nfsd4_create(struct svc_rqst *rqstp, struct nfsd4_compound_state *cstate,
 	struct nfsd_attrs attrs = {
 		.na_iattr	= &create->cr_iattr,
 		.na_seclabel	= &create->cr_label,
+		.na_acltype	= ACL_TYPE_NONE
 	};
 	struct svc_fh resfh;
 	__be32 status;
@@ -770,7 +775,9 @@ nfsd4_create(struct svc_rqst *rqstp, struct nfsd4_compound_state *cstate,
 	if (status)
 		return status;
 
-	status = nfsd4_acl_to_attr(create->cr_type, create->cr_acl, &attrs);
+	nfsd4_setup_attr(cstate->current_fh.fh_dentry, &attrs);
+	status = attrs.na_conv_fn(create->cr_type, create->cr_acl,
+				  &attrs.na_fsacl);
 	current->fs->umask = create->cr_umask;
 	switch (create->cr_type) {
 	case NF4LNK:
@@ -1108,6 +1115,7 @@ nfsd4_setattr(struct svc_rqst *rqstp, struct nfsd4_compound_state *cstate,
 	struct nfsd_attrs attrs = {
 		.na_iattr	= &setattr->sa_iattr,
 		.na_seclabel	= &setattr->sa_label,
+		.na_acltype	= ACL_TYPE_NONE
 	};
 	struct inode *inode;
 	__be32 status = nfs_ok;
@@ -1133,8 +1141,9 @@ nfsd4_setattr(struct svc_rqst *rqstp, struct nfsd4_compound_state *cstate,
 		goto out;
 
 	inode = cstate->current_fh.fh_dentry->d_inode;
-	status = nfsd4_acl_to_attr(S_ISDIR(inode->i_mode) ? NF4DIR : NF4REG,
-				   setattr->sa_acl, &attrs);
+	nfsd4_setup_attr(cstate->current_fh.fh_dentry, &attrs);
+	status = attrs.na_conv_fn(S_ISDIR(inode->i_mode) ? NF4DIR : NF4REG,
+				  setattr->sa_acl, &attrs.na_fsacl);
 
 	if (status)
 		goto out;

--- a/fs/nfsd/nfs4proc.c
+++ b/fs/nfsd/nfs4proc.c
@@ -346,7 +346,7 @@ nfsd4_create_file(struct svc_rqst *rqstp, struct svc_fh *fhp,
 		goto out;
 	}
 
-	if (!IS_POSIXACL(inode))
+	if (!IS_POSIXACL(inode) && !IS_NFSV4ACL(inode))
 		iap->ia_mode &= ~current_umask();
 
 	fh_fill_pre_attrs(fhp);

--- a/fs/nfsd/nfs4xdr.c
+++ b/fs/nfsd/nfs4xdr.c
@@ -2976,7 +2976,8 @@ nfsd4_encode_fattr(struct xdr_stream *xdr, struct svc_fh *fhp,
 
 		memcpy(supp, nfsd_suppattrs[minorversion], sizeof(supp));
 
-		if (!IS_POSIXACL(dentry->d_inode))
+		if (!IS_POSIXACL(dentry->d_inode) &&
+		    !IS_NFSV4ACL(dentry->d_inode))
 			supp[0] &= ~FATTR4_WORD0_ACL;
 		if (!contextsupport)
 			supp[2] &= ~FATTR4_WORD2_SECURITY_LABEL;
@@ -3124,7 +3125,7 @@ out_acl:
 		p = xdr_reserve_space(xdr, 4);
 		if (!p)
 			goto out_resource;
-		*p++ = cpu_to_be32(IS_POSIXACL(dentry->d_inode) ?
+		*p++ = cpu_to_be32(IS_POSIXACL(dentry->d_inode) || IS_NFSV4ACL(dentry->d_inode) ?
 			ACL4_SUPPORT_ALLOW_ACL|ACL4_SUPPORT_DENY_ACL : 0);
 	}
 	if (bmval0 & FATTR4_WORD0_CANSETTIME) {

--- a/fs/nfsd/vfs.c
+++ b/fs/nfsd/vfs.c
@@ -478,15 +478,29 @@ nfsd_setattr(struct svc_rqst *rqstp, struct svc_fh *fhp,
 	if (attr->na_seclabel && attr->na_seclabel->len)
 		attr->na_labelerr = security_inode_setsecctx(dentry,
 			attr->na_seclabel->data, attr->na_seclabel->len);
-	if (IS_ENABLED(CONFIG_FS_POSIX_ACL) && attr->na_pacl)
-		attr->na_aclerr = set_posix_acl(&init_user_ns,
-						inode, ACL_TYPE_ACCESS,
-						attr->na_pacl);
-	if (IS_ENABLED(CONFIG_FS_POSIX_ACL) &&
-	    !attr->na_aclerr && attr->na_dpacl && S_ISDIR(inode->i_mode))
-		attr->na_aclerr = set_posix_acl(&init_user_ns,
-						inode, ACL_TYPE_DEFAULT,
-						attr->na_dpacl);
+
+	switch(attr->na_acltype) {
+	case ACL_TYPE_POSIX:
+		if (IS_ENABLED(CONFIG_FS_POSIX_ACL) && attr->na_fsacl.posixacl.na_pacl)
+			attr->na_aclerr = set_posix_acl(&init_user_ns,
+							inode, ACL_TYPE_ACCESS,
+							attr->na_fsacl.posixacl.na_pacl);
+		if (IS_ENABLED(CONFIG_FS_POSIX_ACL) &&
+		    !attr->na_aclerr && attr->na_fsacl.posixacl.na_dpacl &&
+                    S_ISDIR(inode->i_mode))
+			attr->na_aclerr = set_posix_acl(&init_user_ns,
+							inode, ACL_TYPE_DEFAULT,
+							attr->na_fsacl.posixacl.na_dpacl);
+		break;
+	case ACL_TYPE_ZFS:
+		if (attr->na_fsacl.zfsacl.aclbuf)
+			attr->na_aclerr = nfsv4_set_zfacl_from_attr(dentry, attr);
+		break;
+	case ACL_TYPE_NONE:
+		break;
+	default:
+		BUG();
+	};
 	inode_unlock(inode);
 	if (size_change)
 		put_write_access(inode);
@@ -1303,7 +1317,7 @@ nfsd_create_locked(struct svc_rqst *rqstp, struct svc_fh *fhp,
 		iap->ia_mode = 0;
 	iap->ia_mode = (iap->ia_mode & S_IALLUGO) | type;
 
-	if (!IS_POSIXACL(dirp))
+	if (!IS_POSIXACL(dirp) && !IS_NFSV4ACL(dirp))
 		iap->ia_mode &= ~current_umask();
 
 	err = 0;
@@ -2327,6 +2341,20 @@ nfsd_permission(struct svc_rqst *rqstp, struct svc_export *exp,
 	/* This assumes  NFSD_MAY_{READ,WRITE,EXEC} == MAY_{READ,WRITE,EXEC} */
 	err = inode_permission(&init_user_ns, inode,
 			       acc & (MAY_READ | MAY_WRITE | MAY_EXEC));
+
+	/*
+	 * See RFC 5661 Section 6.2.1.3.2
+	 * Allow NFSv4 ACL to override normal delete permission
+	 * In this case REMOVE is granted if DELETE is granted on file
+	 * or DELETE_CHILD is granted on parent.
+	 */
+	if ((err == -EACCES) && IS_NFSV4ACL(inode) &&
+	    (acc == NFSD_MAY_REMOVE)) {
+		err = inode_permission(&init_user_ns, inode, MAY_DELETE);
+		if (err == -EACCES)
+			err = inode_permission(&init_user_ns, d_inode(dentry->d_parent),
+			    MAY_DELETE_CHILD);
+	}
 
 	/* Allow read access to binaries even when mode 111 */
 	if (err == -EACCES && S_ISREG(inode->i_mode) &&

--- a/fs/nfsd/vfs.h
+++ b/fs/nfsd/vfs.h
@@ -43,21 +43,43 @@ struct nfsd_file;
  */
 typedef int (*nfsd_filldir_t)(void *, const char *, int, loff_t, u64, unsigned);
 
+enum acltype { ACL_TYPE_NONE, ACL_TYPE_POSIX, ACL_TYPE_ZFS };
+typedef struct zacl { u32 *aclbuf; size_t sz; } zacl_t;
+typedef struct pacl { struct posix_acl *na_pacl; struct posix_acl *na_dpacl;} pacl_t;
+typedef union fsacl { zacl_t zfsacl; pacl_t posixacl; } fsacl_t;
+typedef __be32(*aclconv_t)(enum nfs_ftype4, struct nfs4_acl *, fsacl_t *);
+
 /* nfsd/vfs.c */
 struct nfsd_attrs {
 	struct iattr		*na_iattr;	/* input */
 	struct xdr_netobj	*na_seclabel;	/* input */
-	struct posix_acl	*na_pacl;	/* input */
-	struct posix_acl	*na_dpacl;	/* input */
+	fsacl_t			na_fsacl;
+	enum acltype		na_acltype;
 
 	int			na_labelerr;	/* output */
 	int			na_aclerr;	/* output */
+	aclconv_t		na_conv_fn;
 };
 
 static inline void nfsd_attrs_free(struct nfsd_attrs *attrs)
 {
-	posix_acl_release(attrs->na_pacl);
-	posix_acl_release(attrs->na_dpacl);
+	switch(attrs->na_acltype) {
+	case ACL_TYPE_POSIX:
+		posix_acl_release(attrs->na_fsacl.posixacl.na_pacl);
+		posix_acl_release(attrs->na_fsacl.posixacl.na_dpacl);
+		break;
+	case ACL_TYPE_ZFS:
+		kfree(attrs->na_fsacl.zfsacl.aclbuf);
+		attrs->na_fsacl.zfsacl.aclbuf = NULL;
+		attrs->na_fsacl.zfsacl.sz = 0;
+		break;
+	case ACL_TYPE_NONE:
+		break;
+	default:
+		BUG();
+	};
+
+	attrs->na_acltype = ACL_TYPE_NONE;
 }
 
 int		nfsd_cross_mnt(struct svc_rqst *rqstp, struct dentry **dpp,


### PR DESCRIPTION
ZFS currently exposes native ZFS nfsv4 ACL type through the system.nfs4_acl_xdr xattr. underlying ACL type can be determined via inode sb flags (previous kernel work).

This PR makes the Kernel NFS server aware of this ACL type and has it read from and write to the xattr is the relevant NFS40 ops.

At this point only NFS40 ACLs are implemented (RFC3530) because they are currently only ones supported by the Kernel NFS client in Linux.

ACE_INHERITED_ACE is returned in request for NFS40 ACL. This is for consistency with FreeBSD behavior, and is important for SMB / NFS compatibility. At a future point in time, full NFS41 ACL compatibility will most likely be required (for feature parity with other commercial vendors).  nfs4-acl-tools version 0.3.3 and earlier contains a bug where the presence of
ACE_INHERITED_ACE is mistakenly identified as making ACE apply to the file owner.