### PR TITLE
NAS-121995 / 22.12.3 / Disable default enablement of init_on_alloc feature

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -79,3 +79,10 @@ CONFIG_SATA_MOBILE_LPM_POLICY=0
 # used by a driver. Required for plx_eeprom utility.
 #
 CONFIG_IO_STRICT_DEVMEM=n
+
+#
+# Disable init_on_alloc to improve ZFS performance. ZFS allocates and frees
+# pages frequently, and init_on_alloc zeroes out the pages during allocation.
+# Disabling init_on_alloc should improve ZFS performance.
+#
+CONFIG_INIT_ON_ALLOC_DEFAULT_ON=n


### PR DESCRIPTION
Disable init_on_alloc to improve ZFS performance. ZFS allocates and frees pages frequently, and init_on_alloc zeroes out the pages during allocation. Disabling init_on_alloc should improve ZFS performance.