### PR TITLE
NAS-121339 / 23.10 / Build perf package for TrueNAS kernel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,10 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential gawk flex bison openssl dkms \
           libelf-dev libudev-dev libpci-dev libiberty-dev autoconf dwarves \
-          libncurses-dev libssl-dev devscripts
+          libncurses-dev libssl-dev libelf-dev libdw-dev systemtap-sdt-dev \
+          libunwind-dev libslang2-dev libperl-dev binutils-dev libiberty-dev \
+          python3-dev liblzma-dev libzstd-dev libcap-dev libnuma-dev \
+          libbabeltrace-dev openjdk-11-jdk devscripts
 
       - name: Generate .config
         run: |

--- a/scripts/package/builddeb
+++ b/scripts/package/builddeb
@@ -118,8 +118,10 @@ fi
 echo "XXX: Extra version: ${exversion}"
 tmpdir=debian/linux-image
 dbg_dir=debian/linux-image-dbg
+tools_dir=debian/linux-perf
 packagename=linux-image-truenas-$exversion-amd64
 dbg_packagename=$packagename-dbg
+tools_packagename=linux-perf-truenas
 
 if [ "$ARCH" = "um" ] ; then
 	packagename=user-mode-linux-$version
@@ -142,7 +144,7 @@ esac
 BUILD_DEBUG=$(if_enabled_echo CONFIG_DEBUG_INFO Yes)
 
 # Setup the directory structure
-rm -rf "$tmpdir" "$dbg_dir" debian/files
+rm -rf "$tmpdir" "$dbg_dir" "$tools_dir" debian/files
 mkdir -m 755 -p "$tmpdir/DEBIAN"
 mkdir -p "$tmpdir/lib" "$tmpdir/boot"
 
@@ -229,6 +231,19 @@ if [ -n "$BUILD_DEBUG" ] ; then
 	# kdump-tools
 	ln -s lib/modules/$version/vmlinux $dbg_dir/usr/lib/debug/vmlinux-$version
 	create_package "$dbg_packagename" "$dbg_dir"
+fi
+
+if is_enabled CONFIG_PERF_EVENTS && [ "$exversion" = "production" ]; then
+	mkdir -p $tools_dir
+	tools_dest=`readlink -f $tools_dir`
+	if [ -n "$O" ] ; then
+		output=$(readlink -f $objtree)
+		mkdir -p $output/tools/perf
+		output="O=$output/tools/perf"
+	fi
+	$MAKE -C $srctree/tools/perf $output LDFLAGS= srctree=$KBUILD_SRC prefix=$tools_dest/usr install
+	dpkg-shlibdeps $tools_dest/usr/bin/* $tools_dest/usr/lib64/traceevent/plugins/*
+	create_package "$tools_packagename" "$tools_dir"
 fi
 
 exit 0

--- a/scripts/package/mkdebian
+++ b/scripts/package/mkdebian
@@ -200,6 +200,19 @@ Description: Linux kernel debugging symbols for $version
 EOF
 fi
 
+if is_enabled CONFIG_PERF_EVENTS; then
+cat <<EOF >> debian/control
+
+Package: linux-perf-truenas
+Architecture: any
+Replaces: linux-base, linux-tools-common, linux-perf
+Depends: \${shlibs:Depends}
+Description: Performance analysis tools for Linux $version
+ This package contains the 'perf' performance analysis tools for Linux
+ kernel version $version .
+EOF
+fi
+
 cat <<EOF > debian/rules
 #!$(command -v $MAKE) -f
 


### PR DESCRIPTION
Perf package is highly coupled with Linux kernel version present on the system. The sources are present under tools/perf directory. The packages available in upstream Debian repos are specific to Debian Linux kernels and are not compatible with TrueNAS kernels due to version mismatch.

For Bookworm, the stable kernel is v6.1 but it is hard to kep track of kernel packages and update them when Debian does.

It seems we would have to build the perf package. There has been an effort to upstream a patch that updates builddeb to generate a tools package but it looks like it was not accepted for some reason and so far it's being used to generate a perf/tools package with custom kernels.

https://lists.debian.org/debian-kernel/2015/04/msg00013.html

Some adaptations have been made to this patch to make it compatible with latest sources like installing the perf build dependencies to the GitHub CI and updating the control file from mkdebian where other parts of control file are being generated. Package name has been updated to linux-perf-truenas so that it does not conflict with upstream package in Debian repo.

Debian builds the perf package using it's own packaging bits, which does not follow kernel provided packaging. Porting the debian packaging bits here to build the perf package is not worth the effort in my opinion.

Since both production and debug kernel are built from same sources and perf binaries that are built, should be the same for both kernels, perf package is only built with production kernel.