### PR TITLE
NAS-121731 / 23.10 / Disable unnecessary drivers for v6.1

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -86,3 +86,44 @@ CONFIG_INIT_ON_ALLOC_DEFAULT_ON=n
 # used by a driver. Required for plx_eeprom utility.
 #
 CONFIG_IO_STRICT_DEVMEM=n
+
+#
+# Disable Bluetooth
+#
+CONFIG_BT=n
+
+#
+# Disable NFC
+#
+CONFIG_NFC=n
+
+#
+# Disable CAN
+#
+CONFIG_CAN=n
+
+#
+# Disable WiFi and Wireless
+#
+CONFIG_WLAN=n
+CONFIG_WIRELESS=n
+
+#
+# Disable Joystick
+#
+CONFIG_INPUT_JOYSTICK=n
+
+#
+# Disable Media USB support
+#
+CONFIG_MEDIA_USB_SUPPORT=n
+
+#
+# Disable Sony MemoryStick
+#
+CONFIG_MEMSTICK=n
+
+#
+# Disable SoundWire
+#
+CONFIG_SOUNDWIRE=n


### PR DESCRIPTION
This was delayed to look out for any new drivers in 6.1 config that we might want to disable.