### PR TITLE
NAS-123411 / None / nvme: skip optional id ctrl csi for versions less than 2.0.0

### DIFF
--- a/drivers/nvme/host/core.c
+++ b/drivers/nvme/host/core.c
@@ -3116,8 +3116,9 @@ static int nvme_init_non_mdts_limits(struct nvme_ctrl *ctrl)
 	else
 		ctrl->max_zeroes_sectors = 0;
 
+	/* NVME_ID_CNS_CS_CTRL is supported from v2.0.0 onwards. */
 	if (ctrl->subsys->subtype != NVME_NQN_NVME ||
-	    nvme_ctrl_limited_cns(ctrl))
+	    ctrl->vs < NVME_VS(2, 0, 0))
 		return 0;
 
 	id = kzalloc(sizeof(*id), GFP_KERNEL);


### PR DESCRIPTION
The NVME_ID_CNS_CS_CTRL command has been introduced in version 2.0.0. However, this command returns an "Invalid Field" error when executed on previous NVMe versions. In the case of CM6 devices, this error is logged on the error log page. Additionally, for CM6 drives, the reservation commands manipulated by the fenced process indirectly trigger the NVME_ID_CNS_CS_CTRL command every few seconds, leading to a periodic increment in the error count.

While these error entries are harmless, smartctl periodically increases the NVMe error counts. Smartctl displays the increase in NVMe error count due to these errors on both the console and the log file, without providing additional information. To resolve this issue, a simple solution is to skip the NVME_ID_CNS_CS_CTRL command if the version is less than 2.0.0.