### PR TITLE
NAS-123555 / Enable Media USB Support

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -114,11 +114,6 @@ CONFIG_WIRELESS=n
 CONFIG_INPUT_JOYSTICK=n
 
 #
-# Disable Media USB support
-#
-CONFIG_MEDIA_USB_SUPPORT=n
-
-#
 # Disable Sony MemoryStick
 #
 CONFIG_MEMSTICK=n


### PR DESCRIPTION
A user reported that they are not able to use USB TV Tuner device. Enabling media USB support enables the drivers for it.

User confirmed they can use the device after I shared an updated image with media USB support enabled.