### PR TITLE
NAS-124958 / 23.10.1 / Update maintainer for Debian packages and fix GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
 
   pre_build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
@@ -23,12 +23,12 @@ jobs:
     needs: pre_build
     if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -40,7 +40,7 @@ jobs:
       - name: Generate .config
         run: |
           rm -rf .git .gitattributes .gitignore
-          export EXTRAVERSION=-debug
+          sed  -i 's/^EXTRAVERSION.*/EXTRAVERSION = -debug/'  Makefile
           make defconfig
           make syncconfig
           make archprepare
@@ -85,12 +85,12 @@ jobs:
     needs: pre_build
     if: ${{ needs.pre_build.outputs.should_skip != 'true' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -105,7 +105,7 @@ jobs:
       - name: Generate .config
         run: |
           rm -rf .git .gitattributes .gitignore
-          export EXTRAVERSION=-production
+          sed  -i 's/^EXTRAVERSION.*/EXTRAVERSION = -production/'  Makefile
           make defconfig
           make syncconfig
           make archprepare

--- a/scripts/package/mkdebian
+++ b/scripts/package/mkdebian
@@ -8,7 +8,7 @@ set -e
 
 KERNELRELEASE="${KERNELRELEASE:=$(cat include/config/kernel.release)}"
 KDEB_SOURCENAME="${KDEB_SOURCENAME:="linux-$KERNELRELEASE"}"
-MAINTAINER="Andrew Walker <awalker@ixsystems.com>"
+MAINTAINER="Debian Packages List <debian.packages@ixsystems.com>"
 MAKE="${MAKE:="/usr/bin/make"}"
 ARCH="${ARCH:="x86"}"
 


### PR DESCRIPTION
This PR updates the maintainer for Debian packages for Linux kernel.

I discovered couple of issues in GitHub workflows, that are fixed:
* Exporting an environment variable is not straight forward anymore in GitHub actions, instead edit the makefile to set the `EXTRAVERSION` to debug or production.
* actions/checkout@v3 will soon be deprecated, update to use v4 instead.
* Run on Ubuntu 22.04