### PR TITLE
NAS-125686 / 24.04 / Rename FORCE_MAX_ZONEORDER to ARCH_FORCE_MAX_ORDER.

### DIFF
--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -1639,7 +1639,7 @@ config X86_PMEM_LEGACY
 
 	  Say Y if unsure.
 
-config FORCE_MAX_ZONEORDER
+config ARCH_FORCE_MAX_ORDER
 	int "Maximum zone order"
 	default "11"
 	help

--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -8,7 +8,7 @@ CONFIG_TRUENAS=y
 #
 # Processor type and features
 #
-CONFIG_FORCE_MAX_ZONEORDER=14
+CONFIG_ARCH_FORCE_MAX_ORDER=14
 # end of Processor type and features
 
 # CONFIG_MODULE_SIG_ALL is not set


### PR DESCRIPTION
This follows upstream 0192445cb2f7ed1cd7a95a0fc8c7645480baba25.

Due to oversight, this was missed during while updating to 6.6