### PR TITLE
NAS-126872 / None / Disable DCB for Chelsio T4

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -122,3 +122,10 @@ CONFIG_MEMSTICK=n
 # Disable SoundWire
 #
 CONFIG_SOUNDWIRE=n
+
+#
+# Disable Chelsio T4 DCB
+# Users with Chelsio T4 are being spammed on the console about TX Packet
+# without VLAN Tag on DCB Link
+#
+CONFIG_CHELSIO_T4_DCB=n


### PR DESCRIPTION
DCB seems to be generating spam on the console for users with Chelsio T4. Disable DCB features for Chelsio T4.