### PR TITLE
NVME Encapsulation support for Trimode HBA

### DIFF
--- a/drivers/scsi/mpt3sas/mpt3sas_base.h
+++ b/drivers/scsi/mpt3sas/mpt3sas_base.h
@@ -68,6 +68,8 @@
 #include <linux/pci.h>
 #include <linux/poll.h>
 #include <linux/irq_poll.h>
+#include <linux/nvme.h>
+#include <linux/nvme_ioctl.h>
 
 #include "mpt3sas_debug.h"
 #include "mpt3sas_trigger_diag.h"
@@ -625,6 +627,7 @@ static inline void sas_device_put(struct _sas_device *s)
 struct _pcie_device {
 	struct list_head list;
 	struct scsi_target *starget;
+	struct nvme_effects_log *nvme_elog;
 	u64	wwid;
 	u16	handle;
 	u32	device_info;
@@ -1844,6 +1847,9 @@ mpt3sas_raid_device_find_by_handle(struct MPT3SAS_ADAPTER *ioc, u16 handle);
 void mpt3sas_scsih_change_queue_depth(struct scsi_device *sdev, int qdepth);
 struct _sas_device *
 __mpt3sas_get_sdev_by_rphy(struct MPT3SAS_ADAPTER *ioc, struct sas_rphy *rphy);
+struct _pcie_device *
+__mpt3sas_get_pdev_from_target(struct MPT3SAS_ADAPTER *ioc,
+	struct MPT3SAS_TARGET *tgt_priv);
 struct virtual_phy *
 mpt3sas_get_vphy_by_phy(struct MPT3SAS_ADAPTER *ioc,
 	struct hba_port *port, u32 phy);
@@ -2052,6 +2058,14 @@ void mpt3sas_setup_debugfs(struct MPT3SAS_ADAPTER *ioc);
 void mpt3sas_destroy_debugfs(struct MPT3SAS_ADAPTER *ioc);
 void mpt3sas_init_debugfs(void);
 void mpt3sas_exit_debugfs(void);
+
+/* NVME Encapsulation */
+int mpt3_nvme_user_cmd(struct scsi_device *sdev,
+	struct nvme_passthru_cmd __user *ucmd, int is_admin);
+int mpt3_nvme_user_cmd64(struct scsi_device *sdev,
+	struct nvme_passthru_cmd64 __user *ucmd, int is_admin);
+int mpt3_nvme_get_effect_log(struct MPT3SAS_ADAPTER *ioc,
+	struct _pcie_device *pcie_device, struct nvme_effects_log *nvme_elog);
 
 /**
  * _scsih_is_pcie_scsi_device - determines if device is an pcie scsi device

--- a/drivers/scsi/mpt3sas/mpt3sas_ctl.h
+++ b/drivers/scsi/mpt3sas/mpt3sas_ctl.h
@@ -448,4 +448,20 @@ struct mpt3_addnl_diag_query {
 	uint32_t reserved2[2];
 };
 
+/**
+ * struct mpt3_nvme_kencap - hold nvme encap request from scsihost
+ * nvme_encap_rqst - nvme encapsulated request
+ * dout_buf  - output buffer location
+ * din_buf   - input buffer location
+ * reply_buf - reply buffer location
+ * sense_buf - sense buffer location
+ */
+struct mpt3_nvme_kencap {
+	Mpi26NVMeEncapsulatedRequest_t *nvme_encap_rqst;
+	void *dout_buf;
+	void *din_buf;
+	void *reply_buf;
+	void *sense_buf;
+};
+
 #endif /* MPT3SAS_CTL_H_INCLUDED */


### PR DESCRIPTION
This adds support to emulate NVME functionality for the drives connected on Trimode HBA. Userspace tools can talk to the NVME device through passthrough commands, e.g., nvme-cli can identify controller using `nvme id-ctrl /dev/sdX`.

Jira Ticket: https://ixsystems.atlassian.net/browse/NAS-124990

### How Has This Been Tested?
Sanity tested on [TrueNAS Scale 24.10 Custom Build](https://ci.tn.ixsystems.net/jenkins/job/TrueNAS%20SCALE%20-%20Unstable/job/Build%20-%20TrueNAS%20SCALE_Custom/740/) with the following tools along with reservation support:
- NVME cli
- smartctl
- openSeaChest (with patch: https://github.com/ixhamza/openSeaChest/commit/373d35211d25f7e0ac9f32f741c04a5d6c5475d1)