### PR TITLE
NAS-127114 / None / NAS-127114 - Add support for alternate data streams

### DIFF
--- a/fs/smb/client/Makefile
+++ b/fs/smb/client/Makefile
@@ -12,7 +12,7 @@ cifs-y := trace.o cifsfs.o cifs_debug.o connect.o dir.o file.o \
 	  smb2ops.o smb2maperror.o smb2transport.o \
 	  smb2misc.o smb2pdu.o smb2inode.o smb2file.o cifsacl.o fs_context.o \
 	  dns_resolve.o cifs_spnego_negtokeninit.asn1.o asn1.o \
-	  namespace.o
+	  namespace.o truenas_streams.o
 
 $(obj)/asn1.o: $(obj)/cifs_spnego_negtokeninit.asn1.h
 

--- a/fs/smb/client/cifsfs.c
+++ b/fs/smb/client/cifsfs.c
@@ -197,6 +197,7 @@ cifs_read_super(struct super_block *sb)
 	cifs_sb = CIFS_SB(sb);
 	tcon = cifs_sb_master_tcon(cifs_sb);
 
+	sb->s_flags |= SB_LARGEXATTR;
 	if (cifs_sb->mnt_cifs_flags & CIFS_MOUNT_POSIXACL)
 		sb->s_flags |= SB_POSIXACL;
 

--- a/fs/smb/client/cifsglob.h
+++ b/fs/smb/client/cifsglob.h
@@ -2060,6 +2060,7 @@ extern atomic_t mid_count;
 
 #ifdef CONFIG_TRUENAS
 extern unsigned int global_zfsaclflags;
+extern unsigned int streams_samba_compat_enabled;
 #endif
 
 void cifs_oplock_break(struct work_struct *work);

--- a/fs/smb/client/smb2misc.c
+++ b/fs/smb/client/smb2misc.c
@@ -482,6 +482,84 @@ cifs_convert_path_to_utf16(const char *from, struct cifs_sb_info *cifs_sb)
 	return to;
 }
 
+#ifdef CONFIG_TRUENAS
+static const char *
+get_start_of_path(const char *from, struct cifs_sb_info *cifs_sb)
+{
+	/* Windows doesn't allow paths beginning with \ */
+	if (from[0] == '\\')
+		return from + 1;
+
+	/* SMB311 POSIX extensions paths do not include leading slash */
+	else if (cifs_sb_master_tlink(cifs_sb) &&
+		 cifs_sb_master_tcon(cifs_sb)->posix_extensions &&
+		 (from[0] == '/')) {
+		return from + 1;
+	}
+	return from;
+}
+
+/* Note: caller must free return buffer */
+__le16 *
+cifs_convert_stream_path_to_utf16(const char *from, const char *stream, struct cifs_sb_info *cifs_sb)
+{
+	int file_len, stream_len;
+	const char *start_of_path;
+	int map_type;
+	char *buf = NULL, *pbuf;
+	__le16 *file_buf = NULL, *stream_buf = NULL;
+
+	if (cifs_sb->mnt_cifs_flags & CIFS_MOUNT_MAP_SFM_CHR)
+		map_type = SFM_MAP_UNI_RSVD;
+	else if (cifs_sb->mnt_cifs_flags & CIFS_MOUNT_MAP_SPECIAL_CHR)
+		map_type = SFU_MAP_UNI_RSVD;
+	else
+		map_type = NO_MAP_UNI_RSVD;
+
+	start_of_path = get_start_of_path(from, cifs_sb);
+
+	file_buf = cifs_strndup_to_utf16(start_of_path, PATH_MAX, &file_len,
+					 cifs_sb->local_nls, map_type);
+
+	if (file_buf == NULL) {
+		return NULL;
+	}
+
+
+	start_of_path = get_start_of_path(stream, cifs_sb);
+
+	stream_buf = cifs_strndup_to_utf16(start_of_path, PATH_MAX, &stream_len,
+					   cifs_sb->local_nls, map_type);
+	if (stream_buf == NULL) {
+		kfree(file_buf);
+		return NULL;
+	}
+
+	buf = kzalloc(file_len + stream_len, GFP_KERNEL);
+	if (buf == NULL) {
+		kfree(file_buf);
+		kfree(stream_buf);
+		return NULL;
+	}
+
+	memcpy(buf, file_buf, file_len);
+
+	// cifs_strndup_to_utff16 appends two zero bytes
+	// to end of string. We take advantage of this and replace
+	// with UTF-16 colon (separator for file and stream names in
+	// SMB protocol).
+	pbuf = buf + (file_len - 2);
+	*pbuf++ = ':';
+	*pbuf++ = '\0';
+
+	memcpy(pbuf, stream_buf, stream_len);
+	kfree(file_buf);
+	kfree(stream_buf);
+
+	return (__le16 *)buf;
+}
+#endif
+
 __le32
 smb2_get_lease_state(struct cifsInodeInfo *cinode)
 {

--- a/fs/smb/client/smb2misc.c
+++ b/fs/smb/client/smb2misc.c
@@ -499,7 +499,15 @@ get_start_of_path(const char *from, struct cifs_sb_info *cifs_sb)
 	return from;
 }
 
-/* Note: caller must free return buffer */
+/*
+ * This is a variant of cifs_convert_path_to_utf16() for generating a UTF16
+ * path name for a named stream. File name and stream name are separated by the
+ * colon character ":". Since this separator must be preserved in an unaltered
+ * form, the normal path conversion function may not be used to generate a
+ * full stream path.
+ *
+ * Note: caller must free return buffer
+ */
 __le16 *
 cifs_convert_stream_path_to_utf16(const char *from, const char *stream, struct cifs_sb_info *cifs_sb)
 {
@@ -544,10 +552,10 @@ cifs_convert_stream_path_to_utf16(const char *from, const char *stream, struct c
 
 	memcpy(buf, file_buf, file_len);
 
-	// cifs_strndup_to_utff16 appends two zero bytes
-	// to end of string. We take advantage of this and replace
-	// with UTF-16 colon (separator for file and stream names in
-	// SMB protocol).
+	// cifs_strndup_to_utf16() appends a UTF16 NULL character to end of
+	// string. We take advantage of this and replace with UTF-16 colon
+	// (separator for file and stream names in SMB protocol) for
+	// concatenating the full stream name.
 	pbuf = buf + (file_len - 2);
 	*pbuf++ = ':';
 	*pbuf++ = '\0';

--- a/fs/smb/client/smb2pdu.c
+++ b/fs/smb/client/smb2pdu.c
@@ -3772,6 +3772,20 @@ int SMB2_query_info(const unsigned int xid, struct cifs_tcon *tcon,
 			  NULL);
 }
 
+#ifdef CONFIG_TRUENAS
+int SMB2_query_streams(const unsigned int xid, struct cifs_tcon *tcon,
+	u64 persistent_fid, u64 volatile_fid, struct smb2_file_stream_info **data,
+	u32 *plen)
+{
+	*plen = 0;
+	return query_info(xid, tcon, persistent_fid, volatile_fid,
+			  FILE_STREAM_INFORMATION, SMB2_O_INFO_FILE, 0,
+			  (sizeof(struct smb2_file_stream_info) + 255) * 32,
+			  sizeof(struct smb2_file_stream_info), (void **)data,
+			  plen);
+}
+#endif
+
 #if 0
 /* currently unused, as now we are doing compounding instead (see smb311_posix_query_path_info) */
 int

--- a/fs/smb/client/smb2pdu.h
+++ b/fs/smb/client/smb2pdu.h
@@ -413,4 +413,14 @@ struct smb2_posix_info_parsed {
 	const u8 *name;
 };
 
+#ifdef CONFIG_TRUENAS
+struct smb2_file_stream_info {
+	__le32  NextEntryOffset;
+	__le32  StreamNameLength;
+	__le64 StreamSize;
+	__le64 StreamAllocationSize;
+	char   StreamName[];
+} __packed;
+#endif /* CONFIG_TRUENAS */
+
 #endif				/* _SMB2PDU_H */

--- a/fs/smb/client/smb2proto.h
+++ b/fs/smb/client/smb2proto.h
@@ -176,6 +176,13 @@ extern int SMB311_posix_query_info(const unsigned int xid, struct cifs_tcon *tco
 extern int SMB2_query_info(const unsigned int xid, struct cifs_tcon *tcon,
 			   u64 persistent_file_id, u64 volatile_file_id,
 			   struct smb2_file_all_info *data);
+#ifdef CONFIG_TRUENAS
+extern int SMB2_query_streams(const unsigned int xid, struct cifs_tcon *tcon,
+			      u64 persistent_fid, u64 volatile_fid,
+			      struct smb2_file_stream_info **data, u32 *plen);
+__le16 *
+cifs_convert_stream_path_to_utf16(const char *from, const char *stream, struct cifs_sb_info *cifs_sb);
+#endif
 extern int SMB2_query_info_init(struct cifs_tcon *tcon,
 				struct TCP_Server_Info *server,
 				struct smb_rqst *rqst,

--- a/fs/smb/client/truenas_streams.c
+++ b/fs/smb/client/truenas_streams.c
@@ -658,9 +658,11 @@ int list_streams_xattr(struct dentry *dentry, const char *path,
 	if (error)
 		return error;
 
-	error = parse_to_xat_buf(CIFS_SB(dentry->d_sb), dst, dstsz,
-				 streams, (char *)streams + slen,
-				 &slen);
+	if (slen) {
+		error = parse_to_xat_buf(CIFS_SB(dentry->d_sb), dst, dstsz,
+					 streams, (char *)streams + slen,
+					 &slen);
+	}
 	kfree(streams);
 	if (error)
 		return error;

--- a/fs/smb/client/truenas_streams.c
+++ b/fs/smb/client/truenas_streams.c
@@ -535,6 +535,9 @@ get_stream_name(const char *name_in, char **name_out)
 	 * This format matches standard naming convention in Samba's
 	 * vfs_streams_xattr.
 	 *
+	 * `name_out` will contain only the <stream name> portion of `name_in`
+	 * NOTE: caller must free `name_out`.
+	 *
 	 * Some care needs to be taken here because of the following edge case
 	 * Both <filename> and <filename>::$DATA may be used to open the default
 	 * data stream for a file. We need to guard against ever generating the
@@ -568,12 +571,12 @@ get_stream_name(const char *name_in, char **name_out)
 
 	suffix = strstr(stream_name, STREAM_SUFFIX);
 	if (suffix == NULL) {
-		// malformed stream name (no :DATA suffix)
+		// malformed stream name (no :$DATA suffix)
 		kfree(stream_name);
 		return -EINVAL;
 	}
 
-	// chop off :DATA suffix before sending the open request
+	// Remove the stream type suffix and separator ":$DATA"
 	*suffix = '\0';
 	*name_out = stream_name;
 	return 0;

--- a/fs/smb/client/truenas_streams.c
+++ b/fs/smb/client/truenas_streams.c
@@ -1,0 +1,633 @@
+/* SPDX-License-Identifier: LGPL-2.1 */
+/*
+ *
+ *   Copyright (c) iXsystems, inc (2024)
+ *   Author(s): Andrew Walker
+ *
+ */
+
+#include <linux/xattr.h>
+#include "cifspdu.h"
+#include "cifsglob.h"
+#include "cifsproto.h"
+#include "cifs_debug.h"
+#include "truenas_streams.h"
+#include "cifs_unicode.h"
+#include "smb2glob.h"
+#include "smb2pdu.h"
+#include "smb2proto.h"
+
+#define STREAM_MAX_RETRIES 5
+
+unsigned int streams_samba_compat_enabled = 1;
+
+struct parsed_stream_info {
+	u32 size;
+	u32 allocation_size;
+	char *stream_name;
+};
+
+/*
+ * See MS-FSCC 2.4.43 FileStreamInformation
+ *
+ * NOTE regarding stream name:
+ * It is a sequence of unicode characters containing the name of the stream
+ * using the form ":streamname:$DATA" or "::$DATA" for the default data stream.
+ * as specified in MS-FSCC 2.1.4. The field is not null-terminated and MUST
+ * be handled as a sequence of `namelength` bytes.
+ *
+ * NOTE regarding aligment:
+ * When multiple FILE_STREAM_INFORMATION data elements are present in the
+ * buffer, each MUST be alinged on an 8-byte boundaries; any bytes inserted
+ * for alignment SHOULD be set to zero and the receiver MUST ignore them.
+ */
+
+static int
+validate_stream_info(struct smb2_file_stream_info *stream,
+		     char *end)
+{
+	// Check overall stream info
+	char *stream_buf = (char *)stream + sizeof(struct smb2_file_stream_info);
+	if ((stream_buf + stream->StreamNameLength) > end) {
+		return -EOVERFLOW;
+	}
+
+	if (stream->StreamNameLength < DEFAULT_DATA_STREAMLEN) {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static struct smb2_file_stream_info
+*get_next_stream(struct smb2_file_stream_info *in,
+		 char *end_of_streams, int *perror)
+{
+	char *stream_buf = (char *)in;
+
+	if (in->NextEntryOffset == 0) {
+		// MS-FSCC 2.4.43 - zero means no more entries
+		return NULL;
+	}
+
+	stream_buf += in->NextEntryOffset;
+	if (stream_buf > end_of_streams) {
+		*perror = -EOVERFLOW;
+		return NULL;
+	}
+
+	return (struct smb2_file_stream_info *)stream_buf;
+}
+
+static int
+parse_to_xat_buf(struct cifs_sb_info *cifs_sb,
+		 char *dst, size_t dstsz,
+		 struct smb2_file_stream_info *in,
+		 char *end_of_streams,
+		 u32 *pused)
+{
+	char *name = NULL, *stream_name;
+	struct smb2_file_stream_info *stream = NULL;
+	int error = 0;
+	u32 used = 0;
+	size_t namelen = 0;
+
+	for (stream = in;
+	     stream != NULL;
+	     stream = get_next_stream(stream, end_of_streams, &error)) {
+		error = validate_stream_info(stream, end_of_streams);
+		if (error) {
+			break;
+		}
+
+		/*
+		 * `name` is UTF-16 and not NULL-terminated and so convert
+		 * to NULL-terminated UTF-8 string
+		 */
+		name = (char *)stream + sizeof(struct smb2_file_stream_info);
+
+		stream_name = cifs_strndup_from_utf16(name, stream->StreamNameLength, true,
+						      cifs_sb->local_nls);
+		if (stream_name == NULL) {
+			error = -ENOMEM;
+			break;
+		}
+		namelen = strlen(stream_name);
+
+		// skip default data stream. get_next_stream already verified namelen
+		if (strcmp(stream_name, DEFAULT_DATA_STREAM) == 0) {
+			kfree(stream_name);
+			continue;
+		}
+
+		if (dstsz == 0) {
+			used += (namelen + STREAM_XATTR_PREFIXLEN + 1);
+			kfree(stream_name);
+			continue;
+		}
+
+		if ((namelen + STREAM_XATTR_PREFIXLEN) > dstsz) {
+			kfree(stream_name);
+			error = -ERANGE;
+			break;
+		}
+
+		dstsz -= STREAM_XATTR_PREFIXLEN;
+		memcpy(dst, STREAM_XATTR_PREFIX, STREAM_XATTR_PREFIXLEN);
+		dst += STREAM_XATTR_PREFIXLEN;
+
+		// we'll eat the leading ':' in stream name. `namelen` is
+		// fine because we want the terminating NULL to be copied over
+		dstsz -= namelen;
+		memcpy(dst, stream_name + 1, namelen);
+		dst += namelen;
+
+		used += (namelen + STREAM_XATTR_PREFIXLEN);
+		kfree(stream_name);
+	}
+
+	*pused = used;
+	return error;
+}
+
+static int
+get_streams_by_path(struct dentry *dentry, const char *path,
+		    unsigned int xid, struct cifs_tcon *tcon,
+		    struct smb2_file_stream_info **ppstreams,
+		    u32 *pstreamlen)
+{
+	u8 oplock = SMB2_OPLOCK_LEVEL_NONE;
+	struct cifs_sb_info *cifs_sb = CIFS_SB(dentry->d_sb);
+	int rc;
+	struct cifs_fid fid;
+	struct cifs_open_parms oparms;
+	__le16 *utf16_path;
+	struct smb2_file_stream_info *pstreams = NULL;
+	u32 plen;
+
+	cifs_dbg(FYI, "get smb3 streams for path %s\n", path);
+
+	utf16_path = cifs_convert_path_to_utf16(path, cifs_sb);
+	if (!utf16_path) {
+		return -ENOMEM;
+	}
+
+	oparms = (struct cifs_open_parms) {
+		.tcon = tcon,
+		.path = path,
+		.desired_access = FILE_READ_ATTRIBUTES,
+		.disposition = FILE_OPEN,
+		.create_options = cifs_create_options(cifs_sb, 0) |
+			OPEN_REPARSE_POINT,
+		.fid = &fid,
+	};
+
+	// TODO: refactor to use smb2_query_info_compound() to reduce
+	// network traffic. This would require changing path parsing
+	// and so currently beyond scope.
+	rc = SMB2_open(xid, &oparms, utf16_path, &oplock, NULL, NULL, NULL,
+		       NULL);
+	kfree(utf16_path);
+	if (rc)
+		return rc;
+
+
+	rc = SMB2_query_streams(xid, tcon,
+				fid.persistent_fid,
+				fid.volatile_fid,
+				&pstreams, &plen);
+	SMB2_close(xid, tcon, fid.persistent_fid, fid.volatile_fid);
+	if (rc < 0) {
+		return rc;
+	}
+
+	*ppstreams = pstreams;
+	*pstreamlen = plen;
+
+        return 0;
+}
+
+static int
+get_streams_by_fid(const struct cifs_fid *fid,
+		   unsigned int xid, struct cifs_tcon *tcon,
+		   struct smb2_file_stream_info **ppstreams,
+		   u32 *pstreamlen)
+{
+	int rc = -EOPNOTSUPP;
+	u32 plen;
+	struct smb2_file_stream_info *pstreams = NULL;
+
+	rc = SMB2_query_streams(xid, tcon,
+				fid->persistent_fid,
+				fid->volatile_fid,
+				&pstreams, &plen);
+	if (rc < 0) {
+		return rc;
+	}
+
+	*ppstreams = pstreams;
+	*pstreamlen = plen;
+
+	return 0;
+}
+
+static int
+get_smb2_streams(struct dentry *dentry, const char *path,
+		 unsigned int xid, struct cifs_tcon *tcon,
+		 struct smb2_file_stream_info **ppstreams,
+		 u32 *pstreamlen)
+{
+	int error;
+	struct cifsFileInfo *open_file = NULL;
+	struct inode *inode = d_inode(dentry);
+
+	if (inode)
+		open_file = find_readable_file(CIFS_I(inode), true);
+
+	if (!open_file)
+		return get_streams_by_path(dentry, path, xid, tcon, ppstreams, pstreamlen);
+
+	error = get_streams_by_fid(&open_file->fid, xid, tcon, ppstreams, pstreamlen);
+	cifsFileInfo_put(open_file);
+
+	return error;
+}
+
+enum stream_open_type {
+	STREAM_OPEN_READ,
+	STREAM_OPEN_WRITE,
+	STREAM_OPEN_DELETE,
+};
+
+static int
+do_stream_open(struct cifs_tcon *tcon, struct cifs_sb_info *sb,
+	       enum stream_open_type otype, unsigned int xid,
+	       const char *path, const char *stream,
+	       int xattr_flags, struct cifs_fid *fid_out,
+	       struct smb2_file_all_info *info_out)
+{
+	int rc;
+	__le16 *utf16_path = NULL;
+	struct cifs_open_parms oparms;
+	u8 oplock = SMB2_OPLOCK_LEVEL_NONE;
+
+	switch (otype) {
+	case STREAM_OPEN_WRITE:
+		oparms = (struct cifs_open_parms) {
+			.tcon = tcon,
+			.cifs_sb = sb,
+			.desired_access = FILE_WRITE_ATTRIBUTES |
+				FILE_WRITE_DATA | SYNCHRONIZE,
+			.create_options = cifs_create_options(sb, CREATE_NOT_DIR) |
+				OPEN_REPARSE_POINT,
+			.path = path,
+			.fid = fid_out,
+			.mode = ACL_NO_MODE,
+		};
+		switch (xattr_flags) {
+		case XATTR_CREATE:
+			oparms.disposition = FILE_CREATE;
+			break;
+		case XATTR_REPLACE:
+			oparms.disposition = FILE_OPEN;
+			break;
+		default:
+			// We may be able to optimize here by
+			// setting FILE_SUPERSEDE on open and avoid
+			// setting EOF as a separate operation.  
+			oparms.disposition = FILE_OPEN_IF;
+			break;
+		};
+		break;
+	case STREAM_OPEN_READ:
+		oparms = (struct cifs_open_parms) {
+			.tcon = tcon,
+			.cifs_sb = sb,
+			.desired_access = FILE_READ_ATTRIBUTES |
+				FILE_READ_DATA | SYNCHRONIZE,
+			.create_options = cifs_create_options(sb, CREATE_NOT_DIR) |
+				OPEN_REPARSE_POINT,
+			.disposition = FILE_OPEN,
+			.path = path,
+			.fid = fid_out,
+		};
+		break;
+	case STREAM_OPEN_DELETE:
+		oparms = (struct cifs_open_parms) {
+			.tcon = tcon,
+			.cifs_sb = sb,
+			.desired_access = DELETE | FILE_WRITE_ATTRIBUTES,
+			.create_options = cifs_create_options(sb, CREATE_NOT_DIR) |
+				OPEN_REPARSE_POINT | CREATE_DELETE_ON_CLOSE,
+			.disposition = FILE_OPEN,
+			.path = path,
+			.fid = fid_out,
+		};
+		break;
+	default:
+		BUG();
+	};
+
+	utf16_path = cifs_convert_stream_path_to_utf16(path, stream, sb);
+	if (!utf16_path) {
+		return -ENOMEM;
+	}
+
+	rc = SMB2_open(xid, &oparms, utf16_path, &oplock, info_out, NULL, NULL, NULL);
+	kfree(utf16_path);
+
+	return rc;
+}
+
+static int
+delete_stream(struct dentry *dentry, struct cifs_tcon *tcon,
+	      unsigned int xid, const char *path, const char *stream)
+{
+	int rc;
+	struct cifs_fid fid;
+	struct smb2_file_all_info info;
+
+	rc = do_stream_open(tcon, CIFS_SB(dentry->d_sb), STREAM_OPEN_DELETE, xid, path, stream, 0, &fid, &info);
+        if (rc) {
+		// To maintain consistency with removexattr
+		// failure modes, convert ENOENT to ENODATA.
+		if (rc == -ENOENT)
+			rc = -ENODATA;
+
+		return rc;
+        }
+
+	SMB2_close(xid, tcon, fid.persistent_fid, fid.volatile_fid);
+	return rc;
+}
+
+static int
+write_stream(struct dentry *dentry, struct cifs_tcon *tcon,
+	     const char *data, size_t sz, int flags, unsigned int xid,
+	     const char *path, const char *stream)
+{
+	/*
+	 * Write alternate data stream for file specified by dentry.
+	 * The stream is temporarily opened to perform IO (there is
+	 * no open for stream associated in VFS).
+	 */
+	int rc;
+	struct cifs_fid fid;
+	struct cifs_io_parms io_parms;
+	struct kvec iov[2]; // header, data
+	struct smb2_file_all_info info;
+	unsigned int written = 0;
+	unsigned int total_written;
+	unsigned int wsize;
+
+	// We will potentially need to break up stream write into chunks.
+	// Typical IO size in SMB is 1 MiB and typical streams are much
+	// smaller than this.
+	wsize = tcon->ses->server->ops->wp_retry_size(d_inode(dentry));
+
+	// vfs_streams_xattr in Samba appends an extra NULL byte to stream
+	if (streams_samba_compat_enabled) {
+		sz -= streams_samba_compat_enabled;
+	}
+	rc = do_stream_open(tcon, CIFS_SB(dentry->d_sb), STREAM_OPEN_WRITE,
+			    xid, path, stream, flags, &fid, &info);
+        if (rc) {
+		return rc;
+        }
+
+	// We may have a short write and so should loop until
+	// all of payload written
+	for (total_written = 0; sz > total_written;
+	     total_written += written) {
+		unsigned int len = min(wsize, sz - total_written);
+		unsigned int retries = 0;
+		rc = -EAGAIN;
+
+		io_parms = (struct cifs_io_parms) {
+			.persistent_fid = fid.persistent_fid,
+			.volatile_fid = fid.volatile_fid,
+			.pid = current->tgid,
+			.tcon = tcon,
+			.offset = total_written,
+			.length = len,
+		};
+
+		iov[1].iov_base = (char *)data + total_written;
+		iov[1].iov_len = len;
+		while ((rc == -EAGAIN) && ((retries += 1) < STREAM_MAX_RETRIES)) {
+			rc = SMB2_write(xid, &io_parms, &written, iov, 1);
+		}
+
+		if (rc || (written == 0)) {
+			break;
+		}
+	}
+
+	if (total_written < le64_to_cpu(info.EndOfFile)) {
+		int err;
+		__le64 eof = cpu_to_le64(total_written);
+		err = SMB2_set_eof(xid, tcon, fid.persistent_fid,
+		    fid.volatile_fid, current->tgid, &eof);
+	}
+
+	SMB2_close(xid, tcon, fid.persistent_fid, fid.volatile_fid);
+	if (rc) {
+		return rc;
+	}
+
+	return 0;
+}
+
+static int
+read_stream(struct dentry *dentry, struct cifs_tcon *tcon,
+	    char *dst, size_t dstsz, unsigned int xid,
+	    const char *path, const char *stream, u32 *pused)
+{
+	int rc, buf_type = CIFS_NO_BUFFER;
+	struct cifs_fid fid;
+	struct cifs_io_parms io_parms;
+	struct smb2_file_all_info info;
+	unsigned int bytes_read = 0;
+	unsigned int rsize, total_read;
+	u32 to_read;
+
+	rc = do_stream_open(tcon, CIFS_SB(dentry->d_sb), STREAM_OPEN_READ, xid,
+	    path, stream, 0, &fid, &info);
+        if (rc) {
+		return rc;
+        }
+
+	if (dstsz == 0) {
+		SMB2_close(xid, tcon, fid.persistent_fid, fid.volatile_fid);
+		*pused = le64_to_cpu(info.EndOfFile) + streams_samba_compat_enabled;
+		return 0;
+	}
+
+	to_read = le64_to_cpu(info.EndOfFile);
+	if ((to_read >= XATTR_LARGE_SIZE_MAX) ||
+	    ((to_read + streams_samba_compat_enabled) > dstsz)) {
+		/*
+		 * The SMB protocol and MS-FSCC does not provide an upper-bound
+		 * on the maximum size of an alternate data stream. ReFS on
+		 * windows limits ADS max size to 64 KiB, MacOS has no
+		 * real limit on size of resource forks. ZFS doesn't
+		 * have an upper bound on xattr size (these get written as
+		 * files when they're too large), but since our APIs here
+		 * are somewhat terrible (no pwrite / pread equivalent) we
+		 * limit to XATTR_LARGE_SIZE_MAX to reduce maximum allocation
+		 * size that we need to perform.
+		 *
+		 * Typically an alternate data stream will be less than 1 KiB.
+		 */
+
+		SMB2_close(xid, tcon, fid.persistent_fid, fid.volatile_fid);
+		return -ERANGE;
+	}
+
+	rsize = tcon->ses->server->ops->negotiate_rsize(tcon,
+	    CIFS_SB(dentry->d_sb)->ctx);
+
+	for (total_read = 0; to_read > total_read; total_read += bytes_read) {
+		unsigned int len = min(to_read, rsize);
+		unsigned int retries = 0;
+		rc = -EAGAIN;
+		char *pbuf = dst + total_read;
+
+		io_parms = (struct cifs_io_parms) {
+			.persistent_fid = fid.persistent_fid,
+			.volatile_fid = fid.volatile_fid,
+			.pid = current->tgid,
+			.tcon = tcon,
+			.offset = total_read,
+			.length = len,
+		};
+
+		while ((rc == -EAGAIN) && ((retries += 1) < STREAM_MAX_RETRIES)) {
+			rc = SMB2_read(xid, &io_parms, &bytes_read, &pbuf,
+			    &buf_type);
+		}
+
+		// If we've read to end of stream, rc will be 0 and bytes_read 0
+		if (rc || (bytes_read == 0))
+			break;
+	}
+
+	if (streams_samba_compat_enabled) {
+		// Append terminating NULL to match Samba behavior
+		*(dst + total_read + 1) = '\0';
+	}
+
+	SMB2_close(xid, tcon, fid.persistent_fid, fid.volatile_fid);
+	if (rc == 0) {
+		if (streams_samba_compat_enabled) {
+			*pused = total_read + streams_samba_compat_enabled;
+			*(dst + total_read) = '\0';
+		} else {
+			*pused = total_read;
+		}
+	}
+
+	return rc;
+}
+
+static int
+get_stream_name(const char *name_in, char **name_out)
+{
+	char *stream_name, *suffix;
+
+	if (strcmp(name_in, DEFAULT_DATA_STREAM) == 0) {
+		return -EINVAL;
+	}
+
+	stream_name = kstrdup(name_in + STREAM_XATTR_LEN, GFP_KERNEL);
+	if (stream_name == NULL) {
+		return -ENOMEM;
+	}
+
+	suffix = strstr(stream_name, STREAM_SUFFIX);
+	if (suffix == NULL) {
+		// malformed stream name (no :DATA suffix)
+		kfree(stream_name);
+		return -EINVAL;
+	}
+
+	// chop off :DATA suffix before sending the open request
+	*suffix = '\0';
+	*name_out = stream_name;
+
+	return 0;
+}
+
+int set_stream_xattr(struct dentry *dentry, const char *full_path,
+		     unsigned int xid, struct cifs_tcon *tcon,
+		     const char *name, const void *value, size_t size,
+		     int flags)
+{
+	char *stream_name;
+	int rc = 0;
+
+	rc = get_stream_name(name, &stream_name);
+	if (rc) {
+		return rc;
+	}
+
+	if ((value == NULL) && (size == 0)) {
+		rc = delete_stream(dentry, tcon, xid, full_path, stream_name);
+	} else {
+		rc = write_stream(dentry, tcon, value, size, flags, xid,
+				  full_path, stream_name);
+	}
+
+	kfree(stream_name);
+
+	return rc;
+}
+
+int get_stream_xattr(struct dentry *dentry, const char *full_path,
+		     unsigned int xid, struct cifs_tcon *tcon,
+		     const char *name, void *value, size_t size)
+{
+	char *stream_name;
+	u32 used;
+	int rc;
+
+	rc = get_stream_name(name, &stream_name);
+	if (rc) {
+		return rc;
+	}
+
+	rc = read_stream(dentry, tcon, (char *)value, size, xid,
+			 full_path, stream_name, &used);
+	kfree(stream_name);
+	if (rc) {
+		if (rc == -ENOENT)
+			rc = -ENODATA;
+
+		return rc;
+	}
+
+	return used;
+}
+
+int list_streams_xattr(struct dentry *dentry, const char *path,
+                       unsigned int xid, struct cifs_tcon *tcon,
+                       char *dst, size_t dstsz)
+{
+	int error;
+	struct smb2_file_stream_info *streams = NULL;
+	u32 slen;
+
+	error = get_smb2_streams(dentry, path, xid, tcon,
+				 &streams, &slen);
+	if (error)
+		return error;
+
+	error = parse_to_xat_buf(CIFS_SB(dentry->d_sb), dst, dstsz,
+				 streams, (char *)streams + slen,
+				 &slen);
+	kfree(streams);
+	if (error)
+		return error;
+
+	return slen;
+}

--- a/fs/smb/client/truenas_streams.h
+++ b/fs/smb/client/truenas_streams.h
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: LGPL-2.1 */
+/*
+ *
+ *   Copyright (c) iXsystems, inc (2024)
+ *   Author(s): Andrew Walker
+ *
+ */
+
+/*
+ * SMB Protocol Background:
+ * ------------------------
+ * Filesystems presented over the SMB protocol may support alternate data
+ * streams ("named streams") within a file or a directory. This support is
+ * designated by the filesystem attribute FILE_NAMED_STREAMS. Named streams
+ * are not identical to extended attributes (EAs), which may also be
+ * supported by the same SMB server.
+ *
+ * A named stream is a place within a file in addition to the main stream
+ * (normal file data) where data is stored. Named streams have different
+ * data than the main stream (and than each other) and may be written and
+ * read independenly of each other. Named streams for a file are designated
+ * by appending a ":" colon character to the file name followed by the
+ * name of the alternate data stream. Stream names may be no more than 255
+ * characters in length and are subject to the characteristics and
+ * limitations documented in MS-FSCC Section 2.1.5 Pathname and following.
+ *
+ * A list of named streams for a file can be gathered by submitting an
+ * SMB2_QUERY_INFO request for FILE_STREAM_INFORMATION. The expected server
+ * response is documented in MS-FSS Section 2.4.43 FileStreamInformation.
+ *
+ * Streams are typically smallish in size (less than 200 bytes individually),
+ * and are rarely used apart from MacOS SMB clients.
+ *
+ * TrueNAS /ZFS background:
+ * ------------------------
+ * Solaris supported a similar feature set through its file-backed xattr
+ * capabilities and APIs. This meant that the kernel SMB server in solaris
+ * was able to seamlessly provide support for named streams. When ZFS was
+ * ported to FreeBSD and Linux the extattr and xattr OS APIs were layered
+ * on top of the ZFS file-backed xattrs. As time progressed and ZFS on
+ * Linux saw more use, it was determined that the performance and lack of
+ * atomocity of operations on file-backed xattrs was insufficient for
+ * some application requirements (this was especially the case for Samba
+ * shares), this eventually led to the ZFS dataset configuration parameter
+ * for SA-backed xattrs on Linux (which is the TrueNAS default). With this
+ * configuration, xattrs up to a certain size are written as SA, and larger
+ * xattrs are written as files. The practical result of this is that
+ * TrueNAS can support extended attributes that are much greater in size
+ * than a traditional Linux file server. Unforutnately, due to inability
+ * to perform partial reads and writes on extended attributes a 2 MiB
+ * upper bound is placed as the maximum size of a single extended attribute
+ * / named stream in TrueNAS.
+ *
+ * Samba background:
+ * -----------------
+ * Samba has the ability to present extended attributes as named streams
+ * to SMB clients. This is achieved by prepending a special prefix to
+ * the exended attribute (to differentiate the streams xattrs from normal
+ * xattrs that are presented as EAs over the SMB protocol). Due to
+ * historical design decisions, the Samba module in charge of translating
+ * xattrs into streams appends an extra NULL byte to the xattr on writes
+ * to the local filesystem and strips it off when converting to a stream
+ * for SMB clients.
+ *
+ * Implementation details:
+ * -----------------------
+ * This commit adds support for the Linux kernel SMB2/3 client to enumerate
+ * streams on a remote SMB server by including them in the output of
+ * listxattr with the special Samba prefix. Streams may be written to
+ * the remote SMB server via setxattr and read through getxtattr. The
+ * Samba-specific behavior for appending / removing an extra byte to
+ * the xattr can be disabled by setting /proc/fs/cifs/stream_samba_compat
+ * to 0.
+ */
+
+#ifndef _STREAMS_H
+#define _STREAMS_H
+
+#define STREAM_SUFFIX ":$DATA"
+#define DEFAULT_DATA_STREAM ":" STREAM_SUFFIX
+#define DEFAULT_DATA_STREAMLEN (sizeof(DEFAULT_DATA_STREAM) - 1)
+
+/* This is the default Samba prefix for a named stream */
+#define STREAM_XATTR "DosStream."
+#define STREAM_XATTR_LEN (sizeof(STREAM_XATTR) - 1)
+
+#define STREAM_XATTR_PREFIX "user." STREAM_XATTR
+#define STREAM_XATTR_PREFIXLEN (sizeof(STREAM_XATTR_PREFIX) - 1)
+
+int list_streams_xattr(struct dentry *dentry, const char *path,
+		       unsigned int xid, struct cifs_tcon *tcon,
+		       char *dst, size_t dstsz);
+
+int set_stream_xattr(struct dentry *dentry, const char *full_path,
+		     unsigned int xid, struct cifs_tcon *tcon,
+		     const char *name, const void *value, size_t size,
+		     int flags);
+
+int get_stream_xattr(struct dentry *dentry, const char *full_path,
+		     unsigned int xid, struct cifs_tcon *tcon,
+		     const char *name, void *value, size_t size);
+
+#endif /* _STREAMS_H */

--- a/fs/smb/client/truenas_streams.h
+++ b/fs/smb/client/truenas_streams.h
@@ -46,7 +46,7 @@
  * configuration, xattrs up to a certain size are written as SA, and larger
  * xattrs are written as files. The practical result of this is that
  * TrueNAS can support extended attributes that are much greater in size
- * than a traditional Linux file server. Unforutnately, due to inability
+ * than a traditional Linux file server. Unfortunately, due to inability
  * to perform partial reads and writes on extended attributes a 2 MiB
  * upper bound is placed as the maximum size of a single extended attribute
  * / named stream in TrueNAS.

--- a/fs/smb/client/truenas_streams.h
+++ b/fs/smb/client/truenas_streams.h
@@ -18,7 +18,7 @@
  * A named stream is a place within a file in addition to the main stream
  * (normal file data) where data is stored. Named streams have different
  * data than the main stream (and than each other) and may be written and
- * read independenly of each other. Named streams for a file are designated
+ * read independently of each other. Named streams for a file are designated
  * by appending a ":" colon character to the file name followed by the
  * name of the alternate data stream. Stream names may be no more than 255
  * characters in length and are subject to the characteristics and
@@ -31,15 +31,15 @@
  * Streams are typically smallish in size (less than 200 bytes individually),
  * and are rarely used apart from MacOS SMB clients.
  *
- * TrueNAS /ZFS background:
- * ------------------------
+ * TrueNAS / ZFS background:
+ * -------------------------
  * Solaris supported a similar feature set through its file-backed xattr
  * capabilities and APIs. This meant that the kernel SMB server in solaris
  * was able to seamlessly provide support for named streams. When ZFS was
  * ported to FreeBSD and Linux the extattr and xattr OS APIs were layered
  * on top of the ZFS file-backed xattrs. As time progressed and ZFS on
  * Linux saw more use, it was determined that the performance and lack of
- * atomocity of operations on file-backed xattrs was insufficient for
+ * atomicity of operations on file-backed xattrs was insufficient for
  * some application requirements (this was especially the case for Samba
  * shares), this eventually led to the ZFS dataset configuration parameter
  * for SA-backed xattrs on Linux (which is the TrueNAS default). With this
@@ -54,23 +54,39 @@
  * Samba background:
  * -----------------
  * Samba has the ability to present extended attributes as named streams
- * to SMB clients. This is achieved by prepending a special prefix to
- * the exended attribute (to differentiate the streams xattrs from normal
- * xattrs that are presented as EAs over the SMB protocol). Due to
- * historical design decisions, the Samba module in charge of translating
- * xattrs into streams appends an extra NULL byte to the xattr on writes
- * to the local filesystem and strips it off when converting to a stream
- * for SMB clients.
+ * to SMB clients. This is achieved by prepending a special prefix
+ * "user.DosStream." to the extended attribute (to differentiate the streams
+ * xattrs from normal xattrs that are presented as EAs over the SMB protocol).
+ * Due to historical design decisions, the Samba module in charge of translating
+ * xattrs into streams appends an extra NULL byte to the xattr on writes to the
+ * local filesystem and strips it off when converting to a stream for SMB
+ * clients.
  *
  * Implementation details:
  * -----------------------
  * This commit adds support for the Linux kernel SMB2/3 client to enumerate
  * streams on a remote SMB server by including them in the output of
  * listxattr with the special Samba prefix. Streams may be written to
- * the remote SMB server via setxattr and read through getxtattr. The
+ * the remote SMB server via setxattr and read through getxattr. The
  * Samba-specific behavior for appending / removing an extra byte to
  * the xattr can be disabled by setting /proc/fs/cifs/stream_samba_compat
  * to 0.
+ *
+ * Limitations:
+ * ------------
+ * The Linux VFS limits the maximum size of a list of extended attribute
+ * names to 64 KiB (XATTR_LIST_MAX), this imposes a limit on the total number
+ * of named streams that may successfully enumerated per-file. In theory this
+ * should not be an issue since the maximum buffer size for a query-info
+ * response from the SMB2 server is less than 64 KiB.
+ *
+ * The Linux VFS limits the maximum length of an XATTR name to 255
+ * characters. The default xattr prefix and stream type suffix both eat into
+ * the maximum length of name for an alternate data stream that may be
+ * fetch through an xattr handler to 234 characters.
+ *
+ * The TrueNAS kernel limits the maximum size of an XATTR to 2 MiB, see
+ * notes above on TrueNAS / ZFS background.
  */
 
 #ifndef _STREAMS_H
@@ -84,6 +100,10 @@
 #define STREAM_XATTR "DosStream."
 #define STREAM_XATTR_LEN (sizeof(STREAM_XATTR) - 1)
 
+/*
+ * The following is equivalent to SAMBA_XATTR_DOSSTREAM_PREFIX in
+ * source3/include/smb.h in Samba
+ */
 #define STREAM_XATTR_PREFIX "user." STREAM_XATTR
 #define STREAM_XATTR_PREFIXLEN (sizeof(STREAM_XATTR_PREFIX) - 1)
 

--- a/fs/smb/client/xattr.c
+++ b/fs/smb/client/xattr.c
@@ -165,8 +165,9 @@ static int cifs_xattr_set(const struct xattr_handler *handler,
 		    (strncmp(name, STREAM_XATTR, STREAM_XATTR_LEN) == 0)) {
 			rc = set_stream_xattr(dentry, full_path, xid, pTcon,
 					      name, value, size, flags);
+		} else
 #endif /* CONFIG_TRUENAS */
-		} else if (pTcon->ses->server->ops->set_EA) {
+		if (pTcon->ses->server->ops->set_EA) {
 			rc = pTcon->ses->server->ops->set_EA(xid, pTcon,
 				full_path, name, value, (__u16)size,
 				cifs_sb->local_nls, cifs_sb);

--- a/fs/smb/client/xattr.c
+++ b/fs/smb/client/xattr.c
@@ -132,7 +132,12 @@ static int cifs_xattr_set(const struct xattr_handler *handler,
 	/* if proc/fs/cifs/streamstoxattr is set then
 		search server for EAs or streams to
 		returns as xattrs */
+#ifdef CONFIG_TRUENAS
+	if ((size > MAX_EA_VALUE_SIZE) &&
+	    (strncmp(name, STREAM_XATTR, STREAM_XATTR_LEN) != 0)) {
+#else
 	if (size > MAX_EA_VALUE_SIZE) {
+#endif /* CONFIG_TRUENAS */
 		cifs_dbg(FYI, "size of EA value too large\n");
 		rc = -EOPNOTSUPP;
 		goto out;

--- a/fs/smb/client/xattr.c
+++ b/fs/smb/client/xattr.c
@@ -166,7 +166,7 @@ static int cifs_xattr_set(const struct xattr_handler *handler,
 			goto out;
 
 #ifdef CONFIG_TRUENAS
-		if ((pTcon->ses->server->dialect > SMB30_PROT_ID) &&
+		if ((pTcon->ses->server->dialect >= SMB21_PROT_ID) &&
 		    (strncmp(name, STREAM_XATTR, STREAM_XATTR_LEN) == 0)) {
 			rc = set_stream_xattr(dentry, full_path, xid, pTcon,
 					      name, value, size, flags);
@@ -363,7 +363,7 @@ static int cifs_xattr_get(const struct xattr_handler *handler,
 			goto out;
 
 #ifdef CONFIG_TRUENAS
-		if ((pTcon->ses->server->dialect > SMB30_PROT_ID) &&
+		if ((pTcon->ses->server->dialect >= SMB21_PROT_ID) &&
 		    (strncmp(name, STREAM_XATTR, STREAM_XATTR_LEN) == 0)) {
 			rc = get_stream_xattr(dentry, full_path, xid, pTcon,
 					      name, value, size);
@@ -535,8 +535,8 @@ ssize_t cifs_listxattr(struct dentry *direntry, char *data, size_t buf_size)
 		rc += sizeof(CIFS_XATTR_ZFS_ACL);
 	}
 
-	// For now we will limit ADS support to SMB3 or greater
-	if (pTcon->ses->server->dialect >= SMB30_PROT_ID) {
+	// For now we will limit ADS support to SMB 2.10 or greater
+	if (pTcon->ses->server->dialect >= SMB21_PROT_ID) {
 		int res;
 		res = list_streams_xattr(direntry, full_path, xid, pTcon,
 					 data ? data + rc : data,


### PR DESCRIPTION
SMB Protocol Background:
------------------------
Filesystems presented over the SMB protocol may support alternate data streams ("named streams") within a file or a directory. This support is designated by the filesystem attribute FILE_NAMED_STREAMS. Named streams are not identical to extended attributes (EAs), which may also be supported by the same SMB server.

A named stream is a place within a file in addition to the main stream (normal file data) where data is stored. Named streams have different data than the main stream (and than each other) and may be written and read independenly of each other. Named streams for a file are designated by appending a ":" colon character to the file name followed by the name of the alternate data stream. Stream names may be no more than 255 characters in length and are subject to the characteristics and limitations documented in MS-FSCC Section 2.1.5 Pathname and following.

A list of named streams for a file can be gathered by submitting an SMB2_QUERY_INFO request for FILE_STREAM_INFORMATION. The expected server response is documented in MS-FSS Section 2.4.43 FileStreamInformation.

Streams are typically smallish in size (less than 200 bytes individually), and are rarely used apart from MacOS SMB clients.

TrueNAS /ZFS background:
------------------------
Solaris supported a similar feature set through its file-backed xattr capabilities and APIs. This meant that the kernel SMB server in solaris was able to seamlessly provide support for named streams. When ZFS was ported to FreeBSD and Linux the extattr and xattr OS APIs were layered on top of the ZFS file-backed xattrs. As time progressed and ZFS on Linux saw more use, it was determined that the performance and lack of atomocity of operations on file-backed xattrs was insufficient for some application requirements (this was especially the case for Samba shares), this eventually led to the ZFS dataset configuration parameter for System-Attribute (SA) backed xattrs on Linux (which is the TrueNAS default). With this configuration, xattrs up to a certain size are written as SA, and larger xattrs are written as files. The practical result of this is that TrueNAS can support extended attributes that are much greater in size than a traditional Linux file server. Unforutnately, due to inability to perform partial reads and writes on extended attributes a 2 MiB upper bound is placed as the maximum size of a single extended attribute / named stream in TrueNAS.

Samba background:
-----------------
Samba has the ability to present extended attributes as named streams to SMB clients. This is achieved by prepending a special prefix to the exended attribute (to differentiate the streams xattrs from normal xattrs that are presented as EAs over the SMB protocol). Due to historical design decisions, the Samba module in charge of translating xattrs into streams appends an extra NULL byte to the xattr on writes to the local filesystem and strips it off when converting to a stream for SMB clients.

Implementation details:
-----------------------
This commit adds support for the Linux kernel SMB2/3 client to enumerate streams on a remote SMB server by including them in the output of listxattr with the special Samba prefix. Streams may be written to the remote SMB server via setxattr and read through getxtattr. The Samba-specific behavior for appending / removing an extra byte to the xattr can be disabled by setting /proc/fs/cifs/stream_samba_compat to 0.