### PR TITLE
NAS-128788 / 24.04.1 / Temporary disable new Multi-Gen LRU.

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -143,3 +143,9 @@ CONFIG_CHELSIO_T4_DCB=n
 #
 CONFIG_MODULE_COMPRESS_NONE=y
 CONFIG_MODULE_COMPRESS_XZ=n
+
+#
+# Temporary disable new Multi-Gen LRU, trying to evict and swap out
+# too much of page cache when ARC consumes the most of memory, making
+# WebUI, middleware and random user-space applications unresponsive.
+CONFIG_LRU_GEN_ENABLED=n


### PR DESCRIPTION
The new Multi-Gen LRU tries to free all required memory in one pass. But since it has no idea about ARC, it ends up first putting all required pressure on page cache, causing swapping, and then applies the same huge pressure on ARC, that would drop it in half, if ZFS would allow it. Previous LRU code operates in small gradually increasing steps, which even without knowing about ARC is able to reasonably cooperate with it.