### PR TITLE
NAS-130052 / 24.10 / Fix regression in stream truncation

### DIFF
--- a/fs/smb/client/truenas_streams.c
+++ b/fs/smb/client/truenas_streams.c
@@ -434,9 +434,8 @@ write_stream(struct dentry *dentry, struct cifs_tcon *tcon,
 
 	if (total_written < le64_to_cpu(info.EndOfFile)) {
 		int err;
-		__le64 eof = cpu_to_le64(total_written);
 		err = SMB2_set_eof(xid, tcon, fid.persistent_fid,
-		    fid.volatile_fid, current->tgid, &eof);
+		    fid.volatile_fid, current->tgid, total_written);
 	}
 
 	server->ops->close(xid, tcon, &fid);


### PR DESCRIPTION
Upstream commit 6ebfede8d57a615dcbdec7e490faed585153f7f1 changed API for SMB2_set_eof() which introduced regression in truncation of SMB alternate data streams.