### PR TITLE
NAS-130057 / 24.04 / Enable CONFIG_WERROR for TrueNAS kernels

### DIFF
--- a/drivers/ntb/hw/intel/ntb_hw_gen1.c
+++ b/drivers/ntb/hw/intel/ntb_hw_gen1.c
@@ -1778,7 +1778,6 @@ static int intel_ntb_init_pci(struct intel_ntb_dev *ndev, struct pci_dev *pdev)
 	return 0;
 
 err_mmio:
-err_dma_mask:
 	pci_release_regions(pdev);
 err_pci_regions:
 	pci_disable_device(pdev);

--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -149,3 +149,8 @@ CONFIG_MODULE_COMPRESS_XZ=n
 # too much of page cache when ARC consumes the most of memory, making
 # WebUI, middleware and random user-space applications unresponsive.
 CONFIG_LRU_GEN_ENABLED=n
+
+#
+# Compile Linux kernel with warnings as errors
+#
+CONFIG_WERROR=y


### PR DESCRIPTION
This commit enables `CONFIG_ERROR` option that treats all warnings as error during compile time.