### PR TITLE
NAS-130426 / Cherry-pick multi-gen LRU patches for DF

### DIFF
--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -5586,7 +5586,11 @@ static void set_initial_priority(struct pglist_data *pgdat, struct scan_control 
 	/* round down reclaimable and round up sc->nr_to_reclaim */
 	priority = fls_long(reclaimable) - 1 - fls_long(sc->nr_to_reclaim - 1);
 
-	sc->priority = clamp(priority, 0, DEF_PRIORITY);
+	/*
+	 * The estimation is based on LRU pages only, so cap it to prevent
+	 * overshoots of shrinker objects by large margins.
+	 */
+	sc->priority = clamp(priority, DEF_PRIORITY / 2, DEF_PRIORITY);
 }
 
 static void lru_gen_shrink_node(struct pglist_data *pgdat, struct scan_control *sc)
@@ -7351,6 +7355,7 @@ static bool kswapd_shrink_node(pg_data_t *pgdat,
 {
 	struct zone *zone;
 	int z;
+	unsigned long nr_reclaimed = sc->nr_reclaimed;
 
 	/* Reclaim a number of pages proportional to the number of zones */
 	sc->nr_to_reclaim = 0;
@@ -7378,7 +7383,8 @@ static bool kswapd_shrink_node(pg_data_t *pgdat,
 	if (sc->order && sc->nr_reclaimed >= compact_gap(sc->order))
 		sc->order = 0;
 
-	return sc->nr_scanned >= sc->nr_to_reclaim;
+	/* account for progress from mm_account_reclaimed_pages() */
+	return max(sc->nr_scanned, sc->nr_reclaimed - nr_reclaimed) >= sc->nr_to_reclaim;
 }
 
 /* Page allocator PCP high watermark is lowered if reclaim is active. */

--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -5226,7 +5226,6 @@ retry:
 
 		/* retry folios that may have missed folio_rotate_reclaimable() */
 		list_move(&folio->lru, &clean);
-		sc->nr_scanned -= folio_nr_pages(folio);
 	}
 
 	spin_lock_irq(&lruvec->lru_lock);

--- a/scripts/package/truenas/changelog
+++ b/scripts/package/truenas/changelog
@@ -1,3 +1,9 @@
+linux-6.6.32+truenas (6.6.32+truenas-2) sid; urgency=low
+
+  * Cherry-pick multi-gen LRU pacthes.
+
+ -- Debian Packages List <debian.packages@ixsystems.com>  Tue, 6 Aug 2024 11:00:00 +0500
+
 linux-6.6.32+truenas (6.6.32+truenas-1) sid; urgency=low
 
   * Merge upstream v6.6.32 release.


### PR DESCRIPTION
This PR contains 2 commits, that are cherry-picked from v6.6.44 release. These commits contain fixes for multi-gen LRU.

Changelog is also updated.

API tests run can be found [here](http://jenkins.eng.ixsystems.net:8080/job/dragonfish/job/custom/83/console).

Manually tested by creating an ISO and installing on disk. No new warnings or failures found in dmesg logs.