### PR TITLE
NAS-130437 / None / Add quotes around 'callback address' field.

### DIFF
--- a/fs/nfsd/nfs4state.c
+++ b/fs/nfsd/nfs4state.c
@@ -2541,7 +2541,7 @@ static int client_info_show(struct seq_file *m, void *v)
 			clp->cl_nii_time.tv_sec, clp->cl_nii_time.tv_nsec);
 	}
 	seq_printf(m, "callback state: %s\n", cb_state2str(clp->cl_cb_state));
-	seq_printf(m, "callback address: %pISpc\n", &clp->cl_cb_conn.cb_addr);
+	seq_printf(m, "callback address: \"%pISpc\"\n", &clp->cl_cb_conn.cb_addr);
 	drop_client(clp);
 
 	return 0;


### PR DESCRIPTION
### Problem
In middleware, we read `/proc/fs/nfsd/clients/*/info` with a python yaml parser to collect NFSv4 client information.  When IPv6 addresses are used python yaml parser throws an exception on the 'callback address' field.  This is because the field is not quoted. 
The `address` *is* quoted and does not generate any errors with IPv6 addresses.

### Fix
Quote the `callback address` field.

A CI test was created, _but_ the CI environment does not yet fully support IPv6. 

This fix has been pushed to kernel.org: https://lore.kernel.org/lkml/20240807015834.44960-1-mark.grimes@ixsystems.com/T/#u