### PR TITLE
NAS-130649 / 25.04 / Bump up maximum allowed ACL entries for NFS and SMB in kernel

### DIFF
--- a/fs/nfs_common/nfs41acl_xdr.h
+++ b/fs/nfs_common/nfs41acl_xdr.h
@@ -53,7 +53,7 @@
 /*
  * Macros for sanity checks related to XDR and ACL buffer sizes
  */
-#define NFS41ACL_MAX_ENTRIES	128
+#define NFS41ACL_MAX_ENTRIES	1024
 #define ACE4SIZE                (NACE41_LEN * sizeof(u32))
 #define XDRBASE                 (2 * sizeof (u32))
 

--- a/fs/smb/client/nfs41acl_xdr.h
+++ b/fs/smb/client/nfs41acl_xdr.h
@@ -113,7 +113,7 @@
 /*
  * Macros for sanity checks related to XDR and ACL buffer sizes
  */
-#define NFS41ACL_MAX_ENTRIES	128
+#define NFS41ACL_MAX_ENTRIES	1024
 #define ACE4SIZE                (NACE41_LEN * sizeof(u32))
 #define XDRBASE                 (2 * sizeof (u32))
 


### PR DESCRIPTION
nfsd supports up to 1024 ACEs. Windows servers support a security descriptor size of up to 64 KiB, which translates to around 1700 aces, but since we don't locally support that size we'll keep both at 1024 max.