### PR TITLE
Revert "scsi: mpi3mr: Sanitise num_phys"

### DIFF
--- a/drivers/scsi/mpi3mr/mpi3mr_transport.c
+++ b/drivers/scsi/mpi3mr/mpi3mr_transport.c
@@ -1355,21 +1355,11 @@ static struct mpi3mr_sas_port *mpi3mr_sas_port_add(struct mpi3mr_ioc *mrioc,
 	mpi3mr_sas_port_sanity_check(mrioc, mr_sas_node,
 	    mr_sas_port->remote_identify.sas_address, hba_port);
 
-	if (mr_sas_node->num_phys > sizeof(mr_sas_port->phy_mask) * 8)
-		ioc_info(mrioc, "max port count %u could be too high\n",
-		    mr_sas_node->num_phys);
-
 	for (i = 0; i < mr_sas_node->num_phys; i++) {
 		if ((mr_sas_node->phy[i].remote_identify.sas_address !=
 		    mr_sas_port->remote_identify.sas_address) ||
 		    (mr_sas_node->phy[i].hba_port != hba_port))
 			continue;
-
-		if (i > sizeof(mr_sas_port->phy_mask) * 8) {
-			ioc_warn(mrioc, "skipping port %u, max allowed value is %lu\n",
-			    i, sizeof(mr_sas_port->phy_mask) * 8);
-			goto out_fail;
-		}
 		list_add_tail(&mr_sas_node->phy[i].port_siblings,
 		    &mr_sas_port->phy_list);
 		mr_sas_port->num_phys++;

--- a/drivers/scsi/mpi3mr/mpi3mr_transport.c
+++ b/drivers/scsi/mpi3mr/mpi3mr_transport.c
@@ -1366,7 +1366,7 @@ static struct mpi3mr_sas_port *mpi3mr_sas_port_add(struct mpi3mr_ioc *mrioc,
 			continue;
 
 		if (i > sizeof(mr_sas_port->phy_mask) * 8) {
-			ioc_warn(mrioc, "skipping port %u, max allowed value is %zu\n",
+			ioc_warn(mrioc, "skipping port %u, max allowed value is %lu\n",
 			    i, sizeof(mr_sas_port->phy_mask) * 8);
 			goto out_fail;
 		}


### PR DESCRIPTION
It seems to cause probe failures on 9600-16e HBAs with at least ES60G2/G3 JBODs due to PHY numbers not only above 32, but actually even above 64, as bumped in Linux master. Until upstream developers provide anything better, I expect this to get us back where we were with DF, despite being imperfect.