### PR TITLE
NAS-131827 / 24.10.1 / Revert "ata: libata-scsi: Honor the D_SENSE bit for CK_COND=1 and no error

### DIFF
--- a/drivers/ata/libata-scsi.c
+++ b/drivers/ata/libata-scsi.c
@@ -941,8 +941,19 @@ static void ata_gen_passthru_sense(struct ata_queued_cmd *qc)
 				   &sense_key, &asc, &ascq);
 		ata_scsi_set_sense(qc->dev, cmd, sense_key, asc, ascq);
 	} else {
-		/* ATA PASS-THROUGH INFORMATION AVAILABLE */
-		ata_scsi_set_sense(qc->dev, cmd, RECOVERED_ERROR, 0, 0x1D);
+		/*
+		 * ATA PASS-THROUGH INFORMATION AVAILABLE
+		 *
+		 * Note: we are supposed to call ata_scsi_set_sense(), which
+		 * respects the D_SENSE bit, instead of unconditionally
+		 * generating the sense data in descriptor format. However,
+		 * because hdparm, hddtemp, and udisks incorrectly assume sense
+		 * data in descriptor format, without even looking at the
+		 * RESPONSE CODE field in the returned sense data (to see which
+		 * format the returned sense data is in), we are stuck with
+		 * being bug compatible with older kernels.
+		 */
+		scsi_build_sense(cmd, 1, RECOVERED_ERROR, 0, 0x1D);
 	}
 }
 


### PR DESCRIPTION
Cherry-pick upstream commit 88042e41534b6213ce0fab5e3132939a78e654d9

`hdparam -C` before:
```
root@truenas\[~]# hdparm -C /dev/sda  

/dev/sda:
SG_IO: bad/missing sense data, sb[]:  f0 00 01 00 50 00 ff 0a 00 00 00 00 00 1d 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
drive state is:  unknown
```

`hdparm -C` after:
```
root@truenas[/]# hdparm -C /dev/sda

/dev/sda:
 drive state is:  active/idle
```