### PR TITLE
NAS-135640 / 25.04.1 / NFSD: fix hang in nfsd4_shutdown_callback

### DIFF
--- a/fs/nfsd/nfs4callback.c
+++ b/fs/nfsd/nfs4callback.c
@@ -1486,8 +1486,11 @@ nfsd4_run_cb_work(struct work_struct *work)
 		nfsd4_process_cb_update(cb);
 
 	clnt = clp->cl_cb_client;
-	if (!clnt) {
-		/* Callback channel broken, or client killed; give up: */
+	if (!clnt || clp->cl_state == NFSD4_COURTESY) {
+		/*
+		 * Callback channel broken, client killed or
+		 * nfs4_client in courtesy state; give up.
+		 */
 		nfsd41_destroy_cb(cb);
 		return;
 	}


### PR DESCRIPTION
If nfs4_client is in courtesy state then there is no point to send the callback. This causes nfsd4_shutdown_callback to hang since cl_cb_inflight is not 0. This hang lasts about 15 minutes until TCP notifies NFSD that the connection was dropped.

This patch modifies nfsd4_run_cb_work to skip the RPC call if nfs4_client is in courtesy state.


Fixes: 66af25799940 ("NFSD: add courteous server support for thread with only delegation")
Cc: stable@vger.kernel.org
Reviewed-by: Jeff Layton <jlayton@kernel.org>

### Testing
- CI testing
- Sanity tested [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/fangtooth/job/custom/23/)
- [API Tests (In Progress)](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4238/)