### PR TITLE
NAS-135054 / 25.10 / Enable in-tree module signing with ephemeral key

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -167,3 +167,9 @@ CONFIG_MD=n
 # Compile Linux kernel with warnings as errors
 #
 CONFIG_WERROR=y
+
+#
+# Sign all in-tree kernel modules with a build-time generated key
+#
+CONFIG_MODULE_SIG_ALL=y
+CONFIG_MODULE_SIG_KEY="certs/signing_key.pem"


### PR DESCRIPTION
The kernel will auto-generate a keypair at build time if `certs/signing_key.pem` does not exist.

### Testing:
[Scale Built (In progress)](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1097/).