### PR TITLE
Enable kernel lockdown only under EFI Secure Boot

### DIFF
--- a/arch/x86/kernel/setup.c
+++ b/arch/x86/kernel/setup.c
@@ -1070,19 +1070,7 @@ void __init setup_arch(char **cmdline_p)
 	/* Allocate bigger log buffer */
 	setup_log_buf(1);
 
-	if (efi_enabled(EFI_BOOT)) {
-		switch (boot_params.secure_boot) {
-		case efi_secureboot_mode_disabled:
-			pr_info("Secure boot disabled\n");
-			break;
-		case efi_secureboot_mode_enabled:
-			pr_info("Secure boot enabled\n");
-			break;
-		default:
-			pr_info("Secure boot could not be determined\n");
-			break;
-		}
-	}
+	efi_set_secure_boot(boot_params.secure_boot);
 
 	reserve_initrd();
 

--- a/arch/x86/kernel/setup.c
+++ b/arch/x86/kernel/setup.c
@@ -904,6 +904,8 @@ void __init setup_arch(char **cmdline_p)
 	if (efi_enabled(EFI_BOOT))
 		efi_init();
 
+	efi_set_secure_boot(boot_params.secure_boot);
+
 	reserve_ibft_region();
 	x86_init.resources.dmi_setup();
 
@@ -1069,8 +1071,6 @@ void __init setup_arch(char **cmdline_p)
 #endif
 	/* Allocate bigger log buffer */
 	setup_log_buf(1);
-
-	efi_set_secure_boot(boot_params.secure_boot);
 
 	reserve_initrd();
 

--- a/drivers/firmware/efi/Makefile
+++ b/drivers/firmware/efi/Makefile
@@ -25,6 +25,7 @@ subdir-$(CONFIG_EFI_STUB)		+= libstub
 obj-$(CONFIG_EFI_BOOTLOADER_CONTROL)	+= efibc.o
 obj-$(CONFIG_EFI_TEST)			+= test/
 obj-$(CONFIG_EFI_DEV_PATH_PARSER)	+= dev-path-parser.o
+obj-$(CONFIG_EFI)			+= secureboot.o
 obj-$(CONFIG_APPLE_PROPERTIES)		+= apple-properties.o
 obj-$(CONFIG_EFI_RCI2_TABLE)		+= rci2-table.o
 obj-$(CONFIG_EFI_EMBEDDED_FIRMWARE)	+= embedded-firmware.o

--- a/drivers/firmware/efi/secureboot.c
+++ b/drivers/firmware/efi/secureboot.c
@@ -1,0 +1,39 @@
+
+/* Core kernel secure boot support.
+ *
+ * Copyright (C) 2017 Red Hat, Inc. All Rights Reserved.
+ * Written by David Howells (dhowells@redhat.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public Licence
+ * as published by the Free Software Foundation; either version
+ * 2 of the Licence, or (at your option) any later version.
+ */
+
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
+#include <linux/efi.h>
+#include <linux/kernel.h>
+#include <linux/printk.h>
+
+/*
+ * Decide what to do when UEFI secure boot mode is enabled.
+ */
+void __init efi_set_secure_boot(enum efi_secureboot_mode mode)
+{
+	if (efi_enabled(EFI_BOOT)) {
+		switch (mode) {
+		case efi_secureboot_mode_disabled:
+			pr_info("Secure boot disabled\n");
+			break;
+		case efi_secureboot_mode_enabled:
+			set_bit(EFI_SECURE_BOOT, &efi.flags);
+			pr_info("Secure boot enabled\n");
+			break;
+		default:
+			pr_warn("Secure boot could not be determined (mode %u)\n",
+				mode);
+			break;
+		}
+	}
+}

--- a/drivers/firmware/efi/secureboot.c
+++ b/drivers/firmware/efi/secureboot.c
@@ -15,6 +15,7 @@
 #include <linux/efi.h>
 #include <linux/kernel.h>
 #include <linux/printk.h>
+#include <linux/security.h>
 
 /*
  * Decide what to do when UEFI secure boot mode is enabled.
@@ -28,6 +29,10 @@ void __init efi_set_secure_boot(enum efi_secureboot_mode mode)
 			break;
 		case efi_secureboot_mode_enabled:
 			set_bit(EFI_SECURE_BOOT, &efi.flags);
+#ifdef CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT
+			lock_kernel_down("EFI Secure Boot",
+					 LOCKDOWN_INTEGRITY_MAX);
+#endif
 			pr_info("Secure boot enabled\n");
 			break;
 		default:

--- a/include/linux/efi.h
+++ b/include/linux/efi.h
@@ -876,6 +876,14 @@ static inline int efi_range_is_wc(unsigned long start, unsigned long len)
 #define EFI_MEM_ATTR		10	/* Did firmware publish an EFI_MEMORY_ATTRIBUTES table? */
 #define EFI_MEM_NO_SOFT_RESERVE	11	/* Is the kernel configured to ignore soft reservations? */
 #define EFI_PRESERVE_BS_REGIONS	12	/* Are EFI boot-services memory segments available? */
+#define EFI_SECURE_BOOT		13	/* Are we in Secure Boot mode? */
+
+enum efi_secureboot_mode {
+	efi_secureboot_mode_unset,
+	efi_secureboot_mode_unknown,
+	efi_secureboot_mode_disabled,
+	efi_secureboot_mode_enabled,
+};
 
 #ifdef CONFIG_EFI
 /*
@@ -900,6 +908,7 @@ static inline bool efi_rt_services_supported(unsigned int mask)
 	return (efi.runtime_supported_mask & mask) == mask;
 }
 extern void efi_find_mirror(void);
+extern void __init efi_set_secure_boot(enum efi_secureboot_mode mode);
 #else
 static inline bool efi_enabled(int feature)
 {
@@ -919,6 +928,7 @@ static inline bool efi_rt_services_supported(unsigned int mask)
 }
 
 static inline void efi_find_mirror(void) {}
+static inline void efi_set_secure_boot(enum efi_secureboot_mode mode) {}
 #endif
 
 extern int efi_status_to_err(efi_status_t status);
@@ -1136,13 +1146,6 @@ static inline bool efi_runtime_disabled(void) { return true; }
 
 extern void efi_call_virt_check_flags(unsigned long flags, const void *caller);
 extern unsigned long efi_call_virt_save_flags(void);
-
-enum efi_secureboot_mode {
-	efi_secureboot_mode_unset,
-	efi_secureboot_mode_unknown,
-	efi_secureboot_mode_disabled,
-	efi_secureboot_mode_enabled,
-};
 
 static inline
 enum efi_secureboot_mode efi_get_secureboot_mode(efi_get_variable_t *get_var)

--- a/include/linux/security.h
+++ b/include/linux/security.h
@@ -522,6 +522,7 @@ int security_inode_notifysecctx(struct inode *inode, void *ctx, u32 ctxlen);
 int security_inode_setsecctx(struct dentry *dentry, void *ctx, u32 ctxlen);
 int security_inode_getsecctx(struct inode *inode, void **ctx, u32 *ctxlen);
 int security_locked_down(enum lockdown_reason what);
+int lock_kernel_down(const char *where, enum lockdown_reason level);
 int lsm_fill_user_ctx(struct lsm_ctx __user *uctx, u32 *uctx_len,
 		      void *val, size_t val_len, u64 id, u64 flags);
 int security_bdev_alloc(struct block_device *bdev);
@@ -1503,6 +1504,11 @@ static inline int security_inode_getsecctx(struct inode *inode, void **ctx, u32 
 static inline int security_locked_down(enum lockdown_reason what)
 {
 	return 0;
+}
+static inline int
+lock_kernel_down(const char *where, enum lockdown_reason level)
+{
+	return -EOPNOTSUPP;
 }
 static inline int lsm_fill_user_ctx(struct lsm_ctx __user *uctx,
 				    u32 *uctx_len, void *val, size_t val_len,

--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -167,3 +167,8 @@ CONFIG_WERROR=y
 #
 CONFIG_MODULE_SIG_ALL=y
 CONFIG_MODULE_SIG_KEY="certs/signing_key.pem"
+
+#
+# Enable lockdown in case of Secure Boot
+#
+CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y

--- a/security/lockdown/Kconfig
+++ b/security/lockdown/Kconfig
@@ -45,3 +45,18 @@ config LOCK_DOWN_KERNEL_FORCE_CONFIDENTIALITY
 	 disabled.
 
 endchoice
+
+config LOCK_DOWN_IN_EFI_SECURE_BOOT
+	bool "Lock down the kernel in EFI Secure Boot mode"
+	default n
+	depends on SECURITY_LOCKDOWN_LSM
+	depends on EFI
+	select SECURITY_LOCKDOWN_LSM_EARLY
+	help
+	  UEFI Secure Boot provides a mechanism for ensuring that the firmware
+	  will only load signed bootloaders and kernels.  Secure boot mode may
+	  be determined from EFI variables provided by the system firmware if
+	  not indicated by the boot parameters.
+
+	  Enabling this option results in kernel lockdown being
+	  triggered in integrity mode if EFI Secure Boot is set.

--- a/security/lockdown/lockdown.c
+++ b/security/lockdown/lockdown.c
@@ -24,7 +24,7 @@ static const enum lockdown_reason lockdown_levels[] = {LOCKDOWN_NONE,
 /*
  * Put the kernel into lock-down mode.
  */
-static int lock_kernel_down(const char *where, enum lockdown_reason level)
+int lock_kernel_down(const char *where, enum lockdown_reason level)
 {
 	if (kernel_locked_down >= level)
 		return -EPERM;


### PR DESCRIPTION
Cherry-pick two patches from Debian Backports to enable conditional kernel lockdown only when booted under EFI Secure Boot. This ensures backward compatibility, i.e. systems without Secure Boot support or with Secure Boot disabled remain unaffected (e.g. `lockdown=[none]`).
1. [efi-add-an-efi_secure_boot-flag-to-indicate-secure-boot.patch](https://sources.debian.org/data/main/l/linux/6.12.25-1/debian/patches/features/all/lockdown/efi-add-an-efi_secure_boot-flag-to-indicate-secure-b.patch)
2. [efi-lock-down-the-kernel-if-booted-in-secure-boot-mode.patch](https://sources.debian.org/data/main/l/linux/6.12.25-1/debian/patches/features/all/lockdown/efi-lock-down-the-kernel-if-booted-in-secure-boot-mo.patch)

> **Note**: This is one of the requirements of the shim-review process:
“How does your signed kernel enforce lockdown when your system runs with Secure Boot enabled?
Hint: If it does not, we are not likely to sign your shim.”
 
### Testing
- **With Secure Boot Enabled**
```
root@truenas[~]# cat /boot/config-6.12.25-production+truenas | grep SECURE_BOOT
CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
root@truenas[~]# mokutil --sb-state
SecureBoot enabled
root@truenas[~]# cat /sys/kernel/security/lockdown 
none [integrity] confidentiality
```
- **With Secure Boot Disabled**
```
root@truenas[~]# cat /boot/config-6.12.25-production+truenas | grep SECURE_BOOT
CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
root@truenas[~]# mokutil --sb-state
SecureBoot disabled
root@truenas[~]# cat /sys/kernel/security/lockdown 
[none] integrity confidentiality
```
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1151/)
- [API Tests](http://jenkins.eng.ixsystems.net:8080/job/tests/job/api_tests/4742/console)