### PR TITLE
Enable temperature sensor support for DDR5

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -172,3 +172,9 @@ CONFIG_MODULE_SIG_KEY="certs/signing_key.pem"
 # Enable lockdown in case of Secure Boot
 #
 CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
+
+#
+# Enable temperature sensor support for DDR5
+#
+CONFIG_SENSORS_SPD5118=m
+CONFIG_SENSORS_SPD5118_DETECT=y


### PR DESCRIPTION
Compile the SPD5118 module to allow users to load it.

After loading the module, as long as the system exposes the relevant I2C interface and the memory complies with the SPD5118 standard, it should be possible to read the memory module temperature.