### PR TITLE
NAS-137030/26.04/Wrap is_snapdir in CONFIG_TRUENAS.

### DIFF
--- a/fs/nfsd/vfs.c
+++ b/fs/nfsd/vfs.c
@@ -164,8 +164,10 @@ nfsd_cross_mnt(struct svc_rqst *rqstp, struct dentry **dpp,
 	struct path path = {.mnt = mntget(exp->ex_path.mnt),
 			    .dentry = dget(dentry)};
 	unsigned int follow_flags = 0;
-	int is_snapdir = 0;
 	int err = 0;
+#if CONFIG_TRUENAS
+	int is_snapdir = 0;
+#endif /* CONFIG_TRUENAS */
 
 	if (exp->ex_flags & NFSEXP_CROSSMOUNT)
 		follow_flags = LOOKUP_AUTOMOUNT;


### PR DESCRIPTION
Correcting source config issue.   To avoid warnings `is_snapdir` should be wrapped in `CONFIG_TRUENAS`.