### PR TITLE
NAS-137314 / 26.04 / Revert proc lseek regression fix

### DIFF
--- a/fs/proc/generic.c
+++ b/fs/proc/generic.c
@@ -567,8 +567,6 @@ static void pde_set_flags(struct proc_dir_entry *pde)
 	if (pde->proc_ops->proc_compat_ioctl)
 		pde->flags |= PROC_ENTRY_proc_compat_ioctl;
 #endif
-	if (pde->proc_ops->proc_lseek)
-		pde->flags |= PROC_ENTRY_proc_lseek;
 }
 
 struct proc_dir_entry *proc_create_data(const char *name, umode_t mode,

--- a/fs/proc/inode.c
+++ b/fs/proc/inode.c
@@ -473,7 +473,7 @@ static int proc_reg_open(struct inode *inode, struct file *file)
 	typeof_member(struct proc_ops, proc_open) open;
 	struct pde_opener *pdeo;
 
-	if (!pde_has_proc_lseek(pde))
+	if (!pde->proc_ops->proc_lseek)
 		file->f_mode &= ~FMODE_LSEEK;
 
 	if (pde_is_permanent(pde)) {

--- a/fs/proc/internal.h
+++ b/fs/proc/internal.h
@@ -99,11 +99,6 @@ static inline bool pde_has_proc_compat_ioctl(const struct proc_dir_entry *pde)
 #endif
 }
 
-static inline bool pde_has_proc_lseek(const struct proc_dir_entry *pde)
-{
-	return pde->flags & PROC_ENTRY_proc_lseek;
-}
-
 extern struct kmem_cache *proc_dir_entry_cache;
 void pde_free(struct proc_dir_entry *pde);
 

--- a/include/linux/proc_fs.h
+++ b/include/linux/proc_fs.h
@@ -27,7 +27,6 @@ enum {
 
 	PROC_ENTRY_proc_read_iter	= 1U << 1,
 	PROC_ENTRY_proc_compat_ioctl	= 1U << 2,
-	PROC_ENTRY_proc_lseek		= 1U << 3,
 };
 
 struct proc_ops {


### PR DESCRIPTION
This reverts commit fc1072d934f6 which broke network monitoring tools (netdata, xosview, gkrellm) by making `/proc/net/*` files non-seekable, causing `Illegal seek` errors. The issue occurred because `proc_create_net()` functions don't call `pde_set_flags()`, leaving the `PROC_ENTRY_proc_lseek` flag unset, which causes `proc_reg_open()` to incorrectly clear `FMODE_LSEEK`. An upstream fix has been submitted (https://lore.kernel.org/all/20250821105806.1453833-1-wangzijie1@honor.com/T/) and will most likely be included in the next kernel update. We're reverting now to restore critical monitoring functionality while waiting for the proper fix to be backported to stable branch.

### Testing
**Without Revert:**
```
root@truenas[~]# python3 -c "import platform; f=open('/proc/net/dev'); print(f'Kernel: {platform.release()}'); print('Success' if f.seek(0) == 0 else 'Failed')"
Kernel: 6.12.43-production+truenas
Traceback (most recent call last):
  File "<string>", line 1, in <module>
io.UnsupportedOperation: underlying stream is not seekable
```
**With Revert:**
```
root@truenas[~]# python3 -c "import platform; f=open('/proc/net/dev'); print(f'Kernel: {platform.release()}'); print('Success' if f.seek(0) == 0 else 'Failed')"
Kernel: 6.12.43-production+truenas
Success
```
- [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1442/)