### PR TITLE
NAS-137525 / 26.04 / ses: fix NULL dereference accessing sysfs during enclosure removal

### DIFF
--- a/drivers/scsi/ses.c
+++ b/drivers/scsi/ses.c
@@ -1107,6 +1107,13 @@ static void ses_intf_remove_enclosure(struct scsi_device *sdev)
 		edev->poll_task = NULL;
 	}
 
+	/* enclosure_unregister() sets ->cb to NULL callbacks, preventing any
+	 * further SES driver calls. It removes enclosure sysfs entries,
+	 * eliminating the race window. edev remains valid as we hold a ref;
+	 * it will be freed in enclosure_release() via our put_device() below.
+	 */
+	enclosure_unregister(edev);
+
 	ses_dev = edev->scratch;
 	edev->scratch = NULL;
 
@@ -1118,8 +1125,8 @@ static void ses_intf_remove_enclosure(struct scsi_device *sdev)
 	if (edev->components)
 		kfree(edev->component[0].scratch);
 
+	/* Drop last reference from enclosure_find() */
 	put_device(&edev->edev);
-	enclosure_unregister(edev);
 }
 
 static void ses_intf_remove(struct device *cdev)


### PR DESCRIPTION
A race condition exists when `ses_intf_remove_enclosure()` sets `edev->scratch` to NULL while userspace is accessing sysfs attributes. The sysfs read callbacks access `edev->scratch` to get `ses_device`, causing NULL pointer dereference and kernel panic. Fix this by calling `enclosure_unregister()` before clearing `edev->scratch`. Since `enclosure_unregister()` synchronously removes all sysfs entries via `device_unregister()`, no further sysfs access is possible when freeing the ses_device data structures, eliminating the race.

### Testing
- Tested following script on my Qemu environment with HBA passthrough (only one enclosure):
```
while true; do cat /sys/class/enclosure/*/*/fault; done # 1st Terminal
while true; do echo 1 > /sys/bus/scsi/devices/0:0:6:0/delete; echo "0 6 0" > /sys/class/scsi_host/host0/scan; done # 2nd Terminal
```
- @jervin777 will be testing it on real hardware when [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/master/job/custom/1513/) is ready.