### PR TITLE
NAS-137599 / 25.10.0 / scsi: mpi3mr: Fix NVMe ioctl handling for non-PCIe devices (by ixhamza)

### DIFF
--- a/drivers/scsi/mpi3mr/mpi3mr_os.c
+++ b/drivers/scsi/mpi3mr/mpi3mr_os.c
@@ -5425,6 +5425,9 @@ static int mpi3mr_scsih_ioctl(struct scsi_device *sdev, unsigned int cmd, void _
 	struct mpi3mr_tgt_dev *tgt_dev = mpi3mr_get_tgtdev_by_handle(mrioc,
 					sas_target_priv_data->dev_handle);
 
+	if (!tgt_dev || tgt_dev->dev_type != MPI3_DEVICE_DEVFORM_PCIE)
+		return (-EINVAL);
+
 	if ((tgt_dev->dev_spec.pcie_inf.dev_info &
 	    MPI3_DEVICE0_PCIE_DEVICE_INFO_TYPE_MASK) !=
 	    MPI3_DEVICE0_PCIE_DEVICE_INFO_TYPE_NVME_DEVICE) {


### PR DESCRIPTION
The driver incorrectly allows NVMe ioctls on SAS/SATA devices because it accesses `dev_spec.pcie_inf.dev_info` without first checking `dev_type`. For SAS/SATA devices, the `dev_spec` union contains `sas_sata_inf` data, but the driver reads it as `pcie_inf`, misinterpreting the data and potentially matching the NVMe type check, causing `NVME_IOCTL_ID` to incorrectly return 1 (SUCCESS) instead of `-EINVAL`. The only place Jeff is able to reproduce this is M60 Active controller where `sedutil-cli --scan` were showing NVMe identify error for SAS disks on 9600 HBA. Add a `dev_type` check to ensure only PCIe devices proceed with NVMe ioctl handling.

### Testing
- Verified with HBA Passthrough on M60 Active controller that SAS/SATA devices now correctly return `-EINVAL` for NVMe ioctls.
- Waiting for [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/goldeye/job/custom/11/) to test with different device types (SAS/SATA/NVMe) on 9600 HBA for regression

Original PR: https://github.com/truenas/linux/pull/230
