### PR TITLE
NAS-139210 / 26.04 / Expose stx_change_cookie to userspace

### DIFF
--- a/fs/stat.c
+++ b/fs/stat.c
@@ -711,8 +711,14 @@ cp_statx(const struct kstat *stat, struct statx __user *buffer)
 
 	memset(&tmp, 0, sizeof(tmp));
 
+#ifdef CONFIG_TRUENAS
+	/* Expose STX_CHANGE_COOKIE to userspace for samba */
+	tmp.stx_mask = stat->result_mask;
+	tmp.stx_change_cookie = stat->change_cookie;
+#else
 	/* STATX_CHANGE_COOKIE is kernel-only for now */
 	tmp.stx_mask = stat->result_mask & ~STATX_CHANGE_COOKIE;
+#endif
 	tmp.stx_blksize = stat->blksize;
 	/* STATX_ATTR_CHANGE_MONOTONIC is kernel-only for now */
 	tmp.stx_attributes = stat->attributes & ~STATX_ATTR_CHANGE_MONOTONIC;
@@ -760,11 +766,14 @@ int do_statx(int dfd, struct filename *filename, unsigned int flags,
 	if ((flags & AT_STATX_SYNC_TYPE) == AT_STATX_SYNC_TYPE)
 		return -EINVAL;
 
+
+#ifndef CONFIG_TRUENAS
 	/*
 	 * STATX_CHANGE_COOKIE is kernel-only for now. Ignore requests
 	 * from userland.
 	 */
 	mask &= ~STATX_CHANGE_COOKIE;
+#endif
 
 	error = vfs_statx(dfd, filename, flags, &stat, mask);
 	if (error)
@@ -784,11 +793,13 @@ int do_statx_fd(int fd, unsigned int flags, unsigned int mask,
 	if ((flags & AT_STATX_SYNC_TYPE) == AT_STATX_SYNC_TYPE)
 		return -EINVAL;
 
+#ifndef CONFIG_TRUENAS
 	/*
 	 * STATX_CHANGE_COOKIE is kernel-only for now. Ignore requests
 	 * from userland.
 	 */
 	mask &= ~STATX_CHANGE_COOKIE;
+#endif
 
 	error = vfs_statx_fd(fd, flags, &stat, mask);
 	if (error)

--- a/include/linux/stat.h
+++ b/include/linux/stat.h
@@ -63,9 +63,6 @@ struct kstat {
 
 /* These definitions are internal to the kernel for now. Mainly used by nfsd. */
 
-/* mask values */
-#define STATX_CHANGE_COOKIE		0x40000000U	/* Want/got stx_change_attr */
-
 /* file attribute values */
 #define STATX_ATTR_CHANGE_MONOTONIC	0x8000000000000000ULL /* version monotonically increases */
 

--- a/include/uapi/linux/stat.h
+++ b/include/uapi/linux/stat.h
@@ -186,8 +186,11 @@ struct statx {
 	__u32	stx_atomic_write_unit_max_opt;
 	__u32	__spare2[1];
 
+	/* Expose change cookie for durable / persistent handles in samba */
+	__u64	stx_change_cookie;
+
 	/* 0xc0 */
-	__u64	__spare3[8];	/* Spare space for future expansion */
+	__u64	__spare3[7];	/* Spare space for future expansion */
 
 	/* 0x100 */
 };
@@ -219,6 +222,8 @@ struct statx {
 #define STATX_SUBVOL		0x00008000U	/* Want/got stx_subvol */
 #define STATX_WRITE_ATOMIC	0x00010000U	/* Want/got atomic_write_* fields */
 #define STATX_DIO_READ_ALIGN	0x00020000U	/* Want/got dio read alignment info */
+
+#define STATX_CHANGE_COOKIE	0x40000000U	/* Want/got stx_change_attr */
 
 #define STATX__RESERVED		0x80000000U	/* Reserved for future struct statx expansion */
 


### PR DESCRIPTION
This commit exposes the stat change_cookie to userspace. This is required to present samba with authoritative guidance on whether a file has changed for durable handles.