### PR TITLE
NAS-138841 / 26.0 / Revert "Enable CONFIG_NFSD_LEGACY_CLIENT_TRACKING for 6.18"

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -110,13 +110,6 @@ CONFIG_NVME_TARGET_DEBUGFS=y
 CONFIG_NVME_TARGET_AUTH=y
 
 #
-# NFS Server - Enable legacy client tracking for API test compatibility.
-# Debian disabled this in 6.18 as deprecated, but API tests such as
-# test_300_nfs test_state_directory require /proc/fs/nfsd/nfsv4recoverydir.
-#
-CONFIG_NFSD_LEGACY_CLIENT_TRACKING=y
-
-#
 # Disable deprecated tracefs automounting to avoid kernel warning spam.
 # Kernel 9ba817fb7c6a deprecated automounting tracefs in debugfs, printing
 # "Automounting of tracing to debugfs is deprecated and will be removed in 2030"


### PR DESCRIPTION
This reverts commit eb7dc66a66deb5306200f28180fd92f7c2d110c7.

This PR is part of a pair.  The companion PR is https://github.com/truenas/middleware/pull/18112

Tested with a custom build.