### PR TITLE
NAS-140523 / 27.0.0-BETA.1 / NFSD: return ESTALE for snapdir entries when export lookup fails

### DIFF
--- a/fs/nfsd/vfs.c
+++ b/fs/nfsd/vfs.c
@@ -204,8 +204,23 @@ nfsd_cross_mnt(struct svc_rqst *rqstp, struct dentry **dpp,
 		 * allowed without an explicit export of the new
 		 * directory.
 		 */
-		if (err == -ENOENT && !(exp->ex_flags & NFSEXP_V4ROOT))
-			err = 0;
+		if (err == -ENOENT && !(exp->ex_flags & NFSEXP_V4ROOT)) {
+#ifdef CONFIG_TRUENAS
+			/*
+			 * For ZFS snapshot entries under a zfs_snapdir
+			 * export, the fallback dentry is an automount
+			 * stub with simple_dir_operations that returns
+			 * empty READDIR (NFS4_OK, zero entries). The
+			 * client caches this silently with no error
+			 * signal to trigger re-resolution. Return ESTALE
+			 * so the client retries via LOOKUP.
+			 */
+			if (is_snapdir)
+				err = -ESTALE;
+			else
+#endif /* CONFIG_TRUENAS */
+				err = 0;
+		}
 		path_put(&path);
 		goto out;
 	}


### PR DESCRIPTION
When `nfsd_cross_mnt()` crosses into a mounted ZFS snapshot but `rqst_exp_get_by_name()` fails to resolve the sub-export (`-ENOENT`), the error is silently converted to success and the automount stub dentry is returned to the caller. The stub has `simple_dir_operations` and its file handle is encoded with `gen=1` (snapshot is mounted).

This 44-byte `gen=1` handle becomes a permanent trap: `zfsctl_snapdir_vget()` sees `gen=1` matching `d_mountpoint=true`, returns the stub inode, and `READDIR` returns `NFS4_OK` with zero entries. The client caches this empty result indefinitely since there is no error signal to trigger re-resolution. The empty directory persists until change_info4 updates (e.g., manual snapshot creation on the server).

For `zfs_snapdir` exports, return `-ESTALE` instead of silently falling back to the automount stub. This causes the client to re-resolve via `LOOKUP`.

### Testing
```
# Server: setup pool, snapshots, and export with zfs_snapdir
systemctl mask systemd-networkd-wait-online.service
zpool destroy tank 2>/dev/null; echo "" > /etc/exports; exportfs -r
zpool create -f tank -O mountpoint=/mnt/tank sda
zfs create tank/target
dd if=/dev/urandom of=/mnt/tank/target/bigfile bs=1M count=5
for i in 1 2 3 4 5; do echo "snap${i}" > /mnt/tank/target/file${i}.txt; zfs snapshot tank/target@snap${i}; done
echo 0 > /sys/module/zfs/parameters/zfs_expire_snapshot
echo '"/mnt/tank/target" *(rw,sync,no_subtree_check,no_root_squash,zfs_snapdir)' > /etc/exports
exportfs -ra
for i in 1 2 3 4 5; do ls /mnt/tank/target/.zfs/snapshot/snap${i}/ > /dev/null; done

# Client: mount and verify snapshots work
sudo umount /mnt/tank 2>/dev/null; sudo mkdir -p /mnt/tank
sudo mount -t nfs4 -o vers=4.2 192.168.18.9:/mnt/tank/target /mnt/tank
ls /mnt/tank/.zfs/snapshot/snap1/

# Server: inject a negative entry in the nfsd.export cache for snap1.
# This simulates what happens at the customer when zfs destroy triggers
# exportfs_flush (wiping the kernel export cache) and mountd temporarily
# fails to resolve the snapshot sub-export during cache repopulation —
# e.g., due to heavy concurrent activity (long-running zfs recv,
# dsl_process_async_destroys on a large pool).
echo "* /mnt/tank/target/.zfs/snapshot/snap1 $(($(date +%s) + 3600))" > /proc/net/rpc/nfsd.export/channel

# Client: drop page cache and access snap1 again.
# Without fix: snap1 appears as empty directory (NFS4_OK, zero entries).
#   nfsd_cross_mnt silently falls back to the automount stub with gen=1.
#   The client caches this permanently — no error, no retry.
# With fix: snap1 returns ESTALE.
#   nfsd_cross_mnt returns -ESTALE instead of falling back.
#   The client knows the handle is stale and will re-resolve once
#   the negative cache entry expires or is flushed.
echo 2 | sudo tee /proc/sys/vm/drop_caches
ls /mnt/tank/.zfs/snapshot/snap1/
```