### PR TITLE
NAS-140600 / 25.10.2.2 / NFSD: return ESTALE for snapdir entries when automount fails (by ixhamza)

### DIFF
--- a/fs/nfsd/vfs.c
+++ b/fs/nfsd/vfs.c
@@ -188,6 +188,20 @@ nfsd_cross_mnt(struct svc_rqst *rqstp, struct dentry **dpp,
 	    nfsd_mountpoint(dentry, exp) == 2) {
 		/* This is only a mountpoint in some other namespace */
 		path_put(&path);
+#ifdef CONFIG_TRUENAS
+		/*
+		 * For snapdir entries we set LOOKUP_AUTOMOUNT above, so
+		 * if the path is unchanged the automount was attempted
+		 * and failed (EISDIR from zfsctl_snapshot_mount).  This
+		 * can happen transiently when zfs_suspend_fs races with
+		 * the mount helper after the z_teardown_lock deadlock
+		 * fix (see https://github.com/openzfs/zfs/pull/18415).
+		 * Return ESTALE so the client retries via LOOKUP rather
+		 * than caching the ctldir stub as an empty directory.
+		 */
+		if (is_snapdir)
+			err = -ESTALE;
+#endif /* CONFIG_TRUENAS */
 		goto out;
 	}
 


### PR DESCRIPTION
When nfsd_cross_mnt() sets LOOKUP_AUTOMOUNT for a snapdir entry and follow_down() returns with the path unchanged, the automount was attempted and failed (EISDIR from zfsctl_snapshot_mount). The existing code treats this as "mountpoint in some other namespace" and returns success with the ctldir stub dentry.  This stub has simple_dir_operations and produces a 44-byte file handle that returns empty READDIR (NFS4_OK, zero entries) with no error signal for the client to trigger re-resolution. This can happen transiently when zfs_suspend_fs races with mount helper after the z_teardown_lock deadlock fix (https://github.com/openzfs/zfs/pull/18415)

Return `ESTALE` for snapdir entries so the client retries via LOOKUP, which re-triggers the automount.

Original PR: https://github.com/truenas/linux/pull/247
