### PR TITLE
NAS-140669 / 25.10.3.1 / fix stale sysfs symlinks (by yocalebo)

### DIFF
--- a/drivers/scsi/ses.c
+++ b/drivers/scsi/ses.c
@@ -591,6 +591,27 @@ static int ses_enclosure_find_by_addr(struct enclosure_device *edev,
 
 #define INIT_ALLOC_SIZE 32
 
+/*
+ * After a fresh SES read updates every component's scomp->addr, any slot
+ * whose address went back to zero is now empty. Drop the stale binding so
+ * sysfs (/sys/class/enclosure/.../<slot>/device/...) reflects reality. The
+ * add path in ses_enclosure_find_by_addr is the only place bindings are
+ * created during polling; without this symmetric teardown a hot relocation
+ * leaves the source slot permanently pointing at the moved disk.
+ */
+static void ses_remove_stale_components(struct enclosure_device *edev)
+{
+	int i;
+
+	for (i = 0; i < edev->components; i++) {
+		struct enclosure_component *ecomp = &edev->component[i];
+		struct ses_component *scomp = ecomp->scratch;
+
+		if (ecomp->dev && scomp->addr == 0)
+			enclosure_remove_device(edev, ecomp->dev);
+	}
+}
+
 static void ses_enclosure_data_process(struct enclosure_device *edev,
 				       struct scsi_device *sdev,
 				       int create)
@@ -601,13 +622,15 @@ static void ses_enclosure_data_process(struct enclosure_device *edev,
 	struct ses_device *ses_dev = edev->scratch;
 	int types = ses_dev->page1_num_types;
 	unsigned char *hdr_buf = kzalloc(INIT_ALLOC_SIZE, GFP_KERNEL);
+	bool addr_refreshed = false;
 
 	if (!hdr_buf)
 		goto simple_populate;
 
 	/* re-read page 10 */
-	if (ses_dev->page10)
-		ses_recv_diag(sdev, 10, ses_dev->page10, ses_dev->page10_len);
+	if (ses_dev->page10 &&
+	    !ses_recv_diag(sdev, 10, ses_dev->page10, ses_dev->page10_len))
+		addr_refreshed = true;
 	/* Page 7 for the descriptors is optional */
 	result = ses_recv_diag(sdev, 7, hdr_buf, INIT_ALLOC_SIZE);
 	if (result)
@@ -710,6 +733,15 @@ static void ses_enclosure_data_process(struct enclosure_device *edev,
 		spin_unlock(&edev->enc_lock);
 	kfree(buf);
 	kfree(hdr_buf);
+
+	/*
+	 * Only prune bindings when we actually got a fresh page 10 read on
+	 * a refresh call. Skip it on create (no bindings exist yet) and when
+	 * SES was unreachable (scomp->addr values would be stale and could
+	 * cause us to unbind a slot that is still occupied).
+	 */
+	if (!create && addr_refreshed)
+		ses_remove_stale_components(edev);
 }
 
 static int ses_get_enclosure_pci_domain(struct enclosure_device *edev)


### PR DESCRIPTION
# scsi: ses: remove stale enclosure_component bindings during poll

The periodic SES poll added in 62b8212185ab ("Add support to periodically
poll enclosures") only ever calls `enclosure_add_device()`. There is no
matching teardown when a slot's SAS address returns to zero. That same
commit already resets `scomp->addr = 0` when page 10 marks a slot invalid,
but nothing consumed the signal.

When a disk is hot-relocated between enclosures, the poll adds a fresh
binding for the destination slot while leaving the source slot's
`ecomp->dev` pinned to the moved `scsi_device`. The same `scsi_device` is
then bound to two enclosure components. The teardown in
`ses_intf_remove_component()` walks enclosures and breaks after the first
successful `enclosure_remove_device()`, so when the `scsi_device` is later
torn down, one of the two bindings survives and keeps a `get_device()`
reference alive.

On internal SAS hardware this is not just cosmetic. After a relocation
cycle on a 24-drive system, one drive stops enumerating entirely: SES
reports the slot populated with a valid SAS address, but no
`/sys/class/sas_end_device/*` entry and no `scsi_device` ever appear for
that address. A kernel without this patch consistently loses the drive;
a kernel with this patch does not.

The fix adds `ses_remove_stale_components()` and calls it from
`ses_enclosure_data_process()` after the spin-locked region (because
`enclosure_remove_device()` can sleep via `sysfs_remove_link()`). It walks
each component and unbinds any slot where `ecomp->dev` is set but
`scomp->addr == 0`.

It is gated on two conditions:

* `!create` — on the initial probe there are no bindings yet.
* The page 10 re-read in this pass actually succeeded. `ses_recv_diag()`
  can fail (target busy, transport reset); in that case `scomp->addr` is
  carryover from the previous successful read, and acting on it could
  unbind a slot that is still occupied. The patch captures the
  `ses_recv_diag()` return value (previously ignored) into a local
  `addr_refreshed` bool.

Original PR: https://github.com/truenas/linux/pull/251
