### PR TITLE
NAS-140754 / 26.0.0-BETA.2 / Disable in-kernel NTFS3 driver (by yocalebo)

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -167,6 +167,13 @@ CONFIG_MODULE_COMPRESS_XZ=n
 CONFIG_MD=n
 
 #
+# Disable in-kernel NTFS3 driver. TrueNAS does not natively support
+# NTFS, and the in-tree ntfs3 driver has produced kernel panics during
+# filesystem enumeration.
+#
+CONFIG_NTFS3_FS=n
+
+#
 # Compile Linux kernel with warnings as errors
 #
 CONFIG_WERROR=y


### PR DESCRIPTION
Disable in-kernel NTFS3 driver. TrueNAS does not natively support NTFS, and the in-tree ntfs3 driver has produced kernel panics during filesystem enumeration. Furthermore, we removed the ability via our API to mount foreign filesystems years ago.

Original PR: https://github.com/truenas/linux/pull/257
