### PR TITLE
NAS-140871 / 27.0.0-BETA.1 / Set kernel default hostname to "truenas"

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -197,3 +197,12 @@ CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
 # phase before the real root is pivoted in.
 #
 CONFIG_DEFAULT_HOSTNAME="truenas"
+
+#
+# Clear the URL embedded in the DRM panic QR code. Debian sets it to
+# "https://deb.li/panic#", which would lead scanners to a Debian-branded
+# crash-report page. Currently a no-op because DRM_PANIC_SCREEN_QR_CODE
+# depends on CONFIG_RUST which is off in our build, but kept as a guard
+# so the Debian URL cannot leak in if RUST is ever enabled.
+#
+CONFIG_DRM_PANIC_SCREEN_QR_CODE_URL=""

--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -188,3 +188,12 @@ CONFIG_MODULE_SIG_KEY="certs/signing_key.pem"
 # Enable lockdown in case of Secure Boot
 #
 CONFIG_LOCK_DOWN_IN_EFI_SECURE_BOOT=y
+
+#
+# Set the kernel default hostname to "truenas" instead of Debian's
+# "(none)". Userspace overrides this via /etc/hostname within milliseconds
+# of systemd starting, but the kernel default is what `hostname`,
+# `uname -n` and /proc/sys/kernel/hostname report during the initramfs
+# phase before the real root is pivoted in.
+#
+CONFIG_DEFAULT_HOSTNAME="truenas"


### PR DESCRIPTION
Set `CONFIG_DEFAULT_HOSTNAME` to **truenas** instead of Debian's **(none)**, so the system identifies as TrueNAS in the initramfs phase before `/etc/hostname` is read by systemd.

While there, also clear `CONFIG_DRM_PANIC_SCREEN_QR_CODE_URL`, which Debian sets to `https://deb.li/panic#`. This is currently a no-op because the QR feature depends on `CONFIG_RUST` which is off in our build, but the override keeps the Debian URL from leaking in if RUST is enabled later.