### PR TITLE
NAS-141230 / 26.0.0-RC.1 / Fix use-after-free in NVDIMM pmem driver DMA (by amotin)

### DIFF
--- a/drivers/nvdimm/pmem.c
+++ b/drivers/nvdimm/pmem.c
@@ -341,6 +341,8 @@ static bool pmem_dma_submit_bio(struct pmem_device *pmem, struct bio *bio,
 		}
 		last_cookie1 = cookie;
 		i += dmas;
+		if (cb)
+			break;
 	}
 	dma_async_issue_pending(dma_chan1);
 
@@ -372,6 +374,8 @@ static bool pmem_dma_submit_bio(struct pmem_device *pmem, struct bio *bio,
 		}
 		last_cookie2 = cookie;
 		i += 2;
+		if (cb)
+			break;
 	}
 	dma_async_issue_pending(dma_chan2);
 	return true;


### PR DESCRIPTION
bio_for_each_bvec() accesses bio after the last loop iteration. There is a chance that due to context switching by that time the pmem_dma_callback() will already be called and the bio will be freed.  To avoid that access break out of the loop explicitly.

Original PR: https://github.com/truenas/linux/pull/287
