### PR TITLE
NAS-141245 / None / Fix boot-pool import regression on viommu=virtio guests

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -74,6 +74,15 @@ CONFIG_DMA_CMA=y
 CONFIG_SATA_MOBILE_LPM_POLICY=0
 
 #
+# Force virtio-iommu built-in (=y); the Debian base config builds it as a
+# module, which leaves it out of our initramfs. Guests that expose a virtual
+# IOMMU (viommu=virtio) then can't bring up the boot disk in early boot and
+# fail to import boot-pool. Built-in, like AMD_IOMMU/INTEL_IOMMU, keeps it
+# always available.
+#
+CONFIG_VIRTIO_IOMMU=y
+
+#
 # Disable init_on_alloc to improve ZFS performance. ZFS allocates and frees
 # pages frequently, and init_on_alloc zeroes out the pages during allocation.
 # Disabling init_on_alloc should improve ZFS performance.


### PR DESCRIPTION
[Importing the Debian base config](https://github.com/truenas/linux/pull/270/changes/dd5c0a4bb5afc654bd82519ba0b9cfe45b0da6aa) flipped `CONFIG_VIRTIO_IOMMU` to `=m` (which also selects `ACPI_VIOT=y`). With `VIOT` built in, the kernel makes VIOT-mapped devices, including the boot `virtio-scsi` controller, wait on the `virtio-iommu` driver before they can probe, but as a module it isn't in our initramfs. So on guests with a virtual IOMMU (`viommu=virtio`) the boot disk never comes up early and boot-pool import drops to the initramfs shell. Building it `=y` like AMD/INTEL_IOMMU keeps it in the initramfs. Only `viommu=virtio` guests are affected; bare metal and normal VMs are fine.

### Testing

- Reproduced on 25.10.4 (6.12.91) with `viommu=virtio`. Before the patch the boot controller stays in deferred probe and the import fails:
```
[   10.770498] pci 0000:00:06.0: deferred probe pending: (reason unknown)
Begin: Importing ZFS root pool 'boot-pool' ... Failure: 1
cannot import 'boot-pool': no such pool available
Failed to import pool 'boot-pool'.
Manually import the pool and exit.

BusyBox v1.35.0 (Debian 1:1.35.0-4+b4) built-in shell (ash)
(initramfs)
```
- [With the patch `virtio-iommu` is built in](http://jenkins.eng.ixsystems.net:8080/job/goldeye/job/custom/109/), the boot disk probes, and `boot-pool` imports normally.