### PR TITLE
NAS-141460 / 27.0.0-BETA.1 / Disable block device drivers TrueNAS does not use

### DIFF
--- a/scripts/package/truenas/truenas.config
+++ b/scripts/package/truenas/truenas.config
@@ -167,6 +167,15 @@ CONFIG_MODULE_COMPRESS_XZ=n
 CONFIG_MD=n
 
 #
+# NAS-141460: Do not build brd, the RAM-disk block driver. TrueNAS has no use
+# for it, but any root user can load it to create RAM-backed block devices on
+# demand; a customer did this on a production system, creating many RAM disks
+# and breaking HA failover. brd is not used by the kernel, OpenZFS, middleware,
+# or the build, so we do not build it.
+#
+CONFIG_BLK_DEV_RAM=n
+
+#
 # Disable in-kernel NTFS3 driver. TrueNAS does not natively support
 # NTFS, and the in-tree ntfs3 driver has produced kernel panics during
 # filesystem enumeration.


### PR DESCRIPTION
TrueNAS has no use for these block-device drivers, but any root user can load them to create block devices on demand; a customer did this with brd and broke HA failover. Stop building `brd`, `scsi_debug`, the `NVMe-oF loop` and `fcloop targets`, `drbd`, `aoe`, `rbd`, `ublk`, `null_blk`, and `bcache`. `scsi_debug` and the `NVMe-oF` loopbacks especially need this because they appear as ordinary `/dev/sd*` and `/dev/nvme*n*` devices that middleware cannot tell apart from real drives; the rest only reduce attack surface.

### Testing
Tested with [Scale Build](http://jenkins.eng.ixsystems.net:8080/job/custom_build/job/build/310/artifact/TrueNAS-27.0.0-MASTER+20260619-131131.iso). No regressions found from the removed drivers.