### PR TITLE
NAS-141752 / 26.0.0-RC.1 / Improve NTB performance and stability (by amotin)

### DIFF
--- a/drivers/net/ntb_netdev.c
+++ b/drivers/net/ntb_netdev.c
@@ -230,9 +230,12 @@ static netdev_tx_t ntb_netdev_start_xmit(struct sk_buff *skb,
 	return NETDEV_TX_OK;
 
 err:
+	if (rc == -EBUSY)
+		return NETDEV_TX_BUSY;
 	ndev->stats.tx_dropped++;
 	ndev->stats.tx_errors++;
-	return NETDEV_TX_BUSY;
+	dev_kfree_skb_any(skb);
+	return NETDEV_TX_OK;
 }
 
 static enum hrtimer_restart ntb_netdev_tx_timer(struct hrtimer *hrtimer)

--- a/drivers/net/ntb_netdev.c
+++ b/drivers/net/ntb_netdev.c
@@ -49,6 +49,7 @@
  */
 #include <linux/etherdevice.h>
 #include <linux/ethtool.h>
+#include <linux/hrtimer.h>
 #include <linux/module.h>
 #include <linux/pci.h>
 #include <linux/ntb.h>
@@ -62,7 +63,7 @@ MODULE_LICENSE("Dual BSD/GPL");
 MODULE_AUTHOR("Intel Corporation");
 
 /* Time in usecs for tx resource reaper */
-static unsigned int tx_time = 1;
+static unsigned int tx_time = 250;
 
 /* Number of descriptors to free before resuming tx */
 static unsigned int tx_start = 10;
@@ -74,7 +75,9 @@ struct ntb_netdev {
 	struct pci_dev *pdev;
 	struct net_device *ndev;
 	struct ntb_transport_qp *qp;
-	struct timer_list tx_timer;
+	struct hrtimer tx_timer;
+	unsigned int tx_stop_thresh;
+	unsigned int tx_start_thresh;
 };
 
 #define	NTB_TX_TIMEOUT_MS	1000
@@ -158,7 +161,9 @@ static int __ntb_netdev_maybe_stop_tx(struct net_device *netdev,
 	smp_mb();
 
 	if (likely(ntb_transport_tx_free_entry(qp) < size)) {
-		mod_timer(&dev->tx_timer, jiffies + usecs_to_jiffies(tx_time));
+		hrtimer_start(&dev->tx_timer,
+			      ns_to_ktime((u64)tx_time * NSEC_PER_USEC),
+			      HRTIMER_MODE_REL);
 		return -EBUSY;
 	}
 
@@ -197,7 +202,7 @@ static void ntb_netdev_tx_handler(struct ntb_transport_qp *qp, void *qp_data,
 
 	dev_kfree_skb_any(skb);
 
-	if (ntb_transport_tx_free_entry(dev->qp) >= tx_start) {
+	if (ntb_transport_tx_free_entry(dev->qp) >= dev->tx_start_thresh) {
 		/* Make sure anybody stopping the queue after this sees the new
 		 * value of ntb_transport_tx_free_entry()
 		 */
@@ -213,14 +218,14 @@ static netdev_tx_t ntb_netdev_start_xmit(struct sk_buff *skb,
 	struct ntb_netdev *dev = netdev_priv(ndev);
 	int rc;
 
-	ntb_netdev_maybe_stop_tx(ndev, dev->qp, tx_stop);
+	ntb_netdev_maybe_stop_tx(ndev, dev->qp, dev->tx_stop_thresh);
 
 	rc = ntb_transport_tx_enqueue(dev->qp, skb, skb->data, skb->len);
 	if (rc)
 		goto err;
 
 	/* check for next submit */
-	ntb_netdev_maybe_stop_tx(ndev, dev->qp, tx_stop);
+	ntb_netdev_maybe_stop_tx(ndev, dev->qp, dev->tx_stop_thresh);
 
 	return NETDEV_TX_OK;
 
@@ -230,21 +235,24 @@ err:
 	return NETDEV_TX_BUSY;
 }
 
-static void ntb_netdev_tx_timer(struct timer_list *t)
+static enum hrtimer_restart ntb_netdev_tx_timer(struct hrtimer *hrtimer)
 {
-	struct ntb_netdev *dev = timer_container_of(dev, t, tx_timer);
+	struct ntb_netdev *dev = container_of(hrtimer, struct ntb_netdev, tx_timer);
 	struct net_device *ndev = dev->ndev;
 
-	if (ntb_transport_tx_free_entry(dev->qp) < tx_stop) {
-		mod_timer(&dev->tx_timer, jiffies + usecs_to_jiffies(tx_time));
-	} else {
-		/* Make sure anybody stopping the queue after this sees the new
-		 * value of ntb_transport_tx_free_entry()
-		 */
-		smp_mb();
-		if (netif_queue_stopped(ndev))
-			netif_wake_queue(ndev);
+	if (ntb_transport_tx_free_entry(dev->qp) < dev->tx_stop_thresh) {
+		hrtimer_forward_now(hrtimer,
+				    ns_to_ktime((u64)tx_time * NSEC_PER_USEC));
+		return HRTIMER_RESTART;
 	}
+
+	/* Make sure anybody stopping the queue after this sees the new
+	 * value of ntb_transport_tx_free_entry()
+	 */
+	smp_mb();
+	if (netif_queue_stopped(ndev))
+		netif_wake_queue(ndev);
+	return HRTIMER_NORESTART;
 }
 
 static int ntb_netdev_open(struct net_device *ndev)
@@ -269,8 +277,6 @@ static int ntb_netdev_open(struct net_device *ndev)
 		}
 	}
 
-	timer_setup(&dev->tx_timer, ntb_netdev_tx_timer, 0);
-
 	netif_carrier_off(ndev);
 	ntb_transport_link_up(dev->qp);
 	netif_start_queue(ndev);
@@ -289,12 +295,11 @@ static int ntb_netdev_close(struct net_device *ndev)
 	struct sk_buff *skb;
 	int len;
 
+	hrtimer_cancel(&dev->tx_timer);
 	ntb_transport_link_down(dev->qp);
 
 	while ((skb = ntb_transport_rx_remove(dev->qp, &len)))
 		dev_kfree_skb(skb);
-
-	timer_delete_sync(&dev->tx_timer);
 
 	return 0;
 }
@@ -314,6 +319,8 @@ static int ntb_netdev_change_mtu(struct net_device *ndev, int new_mtu)
 	}
 
 	/* Bring down the link and dispose of posted rx entries */
+	netif_stop_queue(ndev);
+	hrtimer_cancel(&dev->tx_timer);
 	ntb_transport_link_down(dev->qp);
 
 	if (ndev->mtu < new_mtu) {
@@ -341,6 +348,7 @@ static int ntb_netdev_change_mtu(struct net_device *ndev, int new_mtu)
 	WRITE_ONCE(ndev->mtu, new_mtu);
 
 	ntb_transport_link_up(dev->qp);
+	netif_wake_queue(ndev);
 
 	return 0;
 
@@ -423,6 +431,8 @@ static int ntb_netdev_probe(struct device *client_dev)
 	dev = netdev_priv(ndev);
 	dev->ndev = ndev;
 	dev->pdev = pdev;
+	hrtimer_setup(&dev->tx_timer, ntb_netdev_tx_timer, CLOCK_MONOTONIC,
+		      HRTIMER_MODE_REL);
 	ndev->features = NETIF_F_HIGHDMA;
 
 	ndev->priv_flags |= IFF_LIVE_ADDR_CHANGE;
@@ -444,6 +454,20 @@ static int ntb_netdev_probe(struct device *client_dev)
 	if (!dev->qp) {
 		rc = -EIO;
 		goto err;
+	}
+
+	/*
+	 * At creation all ring slots are free, so tx_free_entry() returns
+	 * the usable ring depth.  Scale down thresholds for small rings to
+	 * avoid deadlock (tx_start > ring_size means the queue never wakes).
+	 */
+	{
+		unsigned int ring_size = ntb_transport_tx_free_entry(dev->qp);
+
+		dev->tx_start_thresh = min(tx_start, max(1U, ring_size / 2));
+		dev->tx_stop_thresh = max(1U, min(tx_stop, dev->tx_start_thresh - 1));
+		netdev_dbg(ndev, "tx ring depth %u: stop<%u wake>=%u\n",
+			   ring_size, dev->tx_stop_thresh, dev->tx_start_thresh);
 	}
 
 	ndev->mtu = ntb_transport_max_size(dev->qp) - ETH_HLEN;

--- a/drivers/ntb/ntb_transport.c
+++ b/drivers/ntb/ntb_transport.c
@@ -2433,9 +2433,8 @@ int ntb_transport_tx_enqueue(struct ntb_transport_qp *qp, void *cb, void *data,
 	if (!qp || !len)
 		return -EINVAL;
 
-	/* If the qp link is down already, just ignore. */
 	if (!qp->link_is_up)
-		return 0;
+		return -ENETDOWN;
 
 	entry = ntb_list_rm(&qp->ntb_tx_free_q_lock, &qp->tx_free_q);
 	if (!entry) {

--- a/drivers/ntb/ntb_transport.c
+++ b/drivers/ntb/ntb_transport.c
@@ -2579,8 +2579,12 @@ EXPORT_SYMBOL_GPL(ntb_transport_max_size);
 unsigned int ntb_transport_tx_free_entry(struct ntb_transport_qp *qp)
 {
 	unsigned int head = qp->tx_index;
-	unsigned int tail = qp->remote_rx_info->entry;
+	unsigned int tail;
 
+	if (!qp->remote_rx_info)
+		return qp->tx_max_entry - 1;
+
+	tail = qp->remote_rx_info->entry;
 	return tail >= head ? tail - head : qp->tx_max_entry + tail - head;
 }
 EXPORT_SYMBOL_GPL(ntb_transport_tx_free_entry);


### PR DESCRIPTION
On F-series we have very small NTB memory windows of only 1MB, which means only 15 packets queued.  If TX queue gets stopped on the queue overflow, it may resume only 4-8ms (1-2 jiffies) later, which significantly reduces transfer speed.  This change switches to high-resolution timer and period of 250us, plus improves handling of extremely short queues.  With this change with MTU 65510 I see stable transfer speeds of ~1.2GB/s with HTTP+curl, and 15Gb/s with iperf instead of something widely fluctuating.

Original PR: https://github.com/truenas/linux/pull/311
