### PR TITLE
NAS-141769 / 25.10.5 / NTB: ntb_transport: validate length in frame header (by amotin)

### DIFF
--- a/drivers/ntb/ntb_transport.c
+++ b/drivers/ntb/ntb_transport.c
@@ -1798,7 +1798,18 @@ static int ntb_process_rxc(struct ntb_transport_qp *qp)
 	entry->rx_hdr = hdr;
 	entry->rx_index = qp->rx_index;
 
-	if (hdr->len > entry->len) {
+	if (hdr->len > qp->rx_max_frame - sizeof(struct ntb_payload_header)) {
+		dev_err_ratelimited(&qp->ndev->pdev->dev,
+			"qp %d: RX frame too large from peer: %u > %zu\n",
+			qp->qp_num, hdr->len,
+			qp->rx_max_frame - sizeof(struct ntb_payload_header));
+		qp->rx_err_oflow++;
+
+		entry->len = -EIO;
+		entry->flags |= DESC_DONE_FLAG;
+
+		ntb_complete_rxc(qp);
+	} else if (hdr->len > entry->len) {
 		dev_dbg(&qp->ndev->pdev->dev,
 			"receive buffer overflow! Wanted %d got %d\n",
 			hdr->len, entry->len);


### PR DESCRIPTION
In case consumer provide receive buffer bigger than frame size, misbehaving peer can cause read beyond the frame end.  Explicit check should prevent it.

Original PR: https://github.com/truenas/linux/pull/314
