### PR TITLE
NAS-142112 / None / Fix nfsd client teardown hang from leaked callback count

### DIFF
--- a/fs/nfsd/nfs4callback.c
+++ b/fs/nfsd/nfs4callback.c
@@ -1204,6 +1204,7 @@ static void nfsd41_destroy_cb(struct nfsd4_callback *cb)
 
 	trace_nfsd_cb_destroy(clp, cb);
 	nfsd41_cb_release_slot(cb);
+	clear_bit(NFSD4_CALLBACK_RUNNING, &cb->cb_flags);
 	if (cb->cb_ops && cb->cb_ops->release)
 		cb->cb_ops->release(cb);
 	nfsd41_cb_inflight_end(clp);
@@ -1523,6 +1524,7 @@ void nfsd4_init_cb(struct nfsd4_callback *cb, struct nfs4_client *clp,
 	cb->cb_msg.rpc_proc = &nfs4_cb_procedures[op];
 	cb->cb_msg.rpc_argp = cb;
 	cb->cb_msg.rpc_resp = cb;
+	cb->cb_flags = 0;
 	cb->cb_ops = ops;
 	INIT_WORK(&cb->cb_work, nfsd4_run_cb_work);
 	cb->cb_status = 0;

--- a/fs/nfsd/nfs4layouts.c
+++ b/fs/nfsd/nfs4layouts.c
@@ -341,9 +341,10 @@ nfsd4_recall_file_layout(struct nfs4_layout_stateid *ls)
 	atomic_inc(&ls->ls_stid.sc_file->fi_lo_recalls);
 	trace_nfsd_layout_recall(&ls->ls_stid.sc_stateid);
 
-	refcount_inc(&ls->ls_stid.sc_count);
-	nfsd4_run_cb(&ls->ls_recall);
-
+	if (!test_and_set_bit(NFSD4_CALLBACK_RUNNING, &ls->ls_recall.cb_flags)) {
+		refcount_inc(&ls->ls_stid.sc_count);
+		nfsd4_run_cb(&ls->ls_recall);
+	}
 out_unlock:
 	spin_unlock(&ls->ls_lock);
 }

--- a/fs/nfsd/nfs4proc.c
+++ b/fs/nfsd/nfs4proc.c
@@ -1777,7 +1777,7 @@ static void nfsd4_send_cb_offload(struct nfsd4_copy *copy)
 		      NFSPROC4_CLNT_CB_OFFLOAD);
 	trace_nfsd_cb_offload(copy->cp_clp, &cbo->co_res.cb_stateid,
 			      &cbo->co_fh, copy->cp_count, copy->nfserr);
-	nfsd4_run_cb(&cbo->co_cb);
+	nfsd4_try_run_cb(&cbo->co_cb);
 }
 
 /**

--- a/fs/nfsd/nfs4state.c
+++ b/fs/nfsd/nfs4state.c
@@ -3165,8 +3165,10 @@ static void nfs4_cb_getattr(struct nfs4_cb_fattr *ncf)
 	/* set to proper status when nfsd4_cb_getattr_done runs */
 	ncf->ncf_cb_status = NFS4ERR_IO;
 
-	refcount_inc(&dp->dl_stid.sc_count);
-	nfsd4_run_cb(&ncf->ncf_getattr);
+	if (!test_and_set_bit(NFSD4_CALLBACK_RUNNING, &ncf->ncf_getattr.cb_flags)) {
+		refcount_inc(&dp->dl_stid.sc_count);
+		nfsd4_run_cb(&ncf->ncf_getattr);
+	}
 }
 
 static struct nfs4_client *create_client(struct xdr_netobj name,
@@ -5312,6 +5314,10 @@ static const struct nfsd4_callback_ops nfsd4_cb_recall_ops = {
 static void nfsd_break_one_deleg(struct nfs4_delegation *dp)
 {
 	bool queued;
+
+	if (test_and_set_bit(NFSD4_CALLBACK_RUNNING, &dp->dl_recall.cb_flags))
+		return;
+
 	/*
 	 * We're assuming the state code never drops its reference
 	 * without first removing the lease.  Since we're in this lease
@@ -6807,7 +6813,7 @@ deleg_reaper(struct nfsd_net *nn)
 		clp->cl_ra->ra_bmval[0] = BIT(RCA4_TYPE_MASK_RDATA_DLG) |
 						BIT(RCA4_TYPE_MASK_WDATA_DLG);
 		trace_nfsd_cb_recall_any(clp->cl_ra);
-		nfsd4_run_cb(&clp->cl_ra->ra_cb);
+		nfsd4_try_run_cb(&clp->cl_ra->ra_cb);
 	}
 }
 
@@ -7736,7 +7742,7 @@ nfsd4_lm_notify(struct file_lock *fl)
 
 	if (queue) {
 		trace_nfsd_cb_notify_lock(lo, nbl);
-		nfsd4_run_cb(&nbl->nbl_cb);
+		nfsd4_try_run_cb(&nbl->nbl_cb);
 	}
 }
 

--- a/fs/nfsd/nfs4state.c
+++ b/fs/nfsd/nfs4state.c
@@ -5328,8 +5328,10 @@ static void nfsd_break_one_deleg(struct nfs4_delegation *dp)
 	refcount_inc(&dp->dl_stid.sc_count);
 	queued = nfsd4_run_cb(&dp->dl_recall);
 	WARN_ON_ONCE(!queued);
-	if (!queued)
+	if (!queued) {
 		refcount_dec(&dp->dl_stid.sc_count);
+		clear_bit(NFSD4_CALLBACK_RUNNING, &dp->dl_recall.cb_flags);
+	}
 }
 
 /* Called from break_lease() with flc_lock held. */

--- a/fs/nfsd/state.h
+++ b/fs/nfsd/state.h
@@ -67,6 +67,8 @@ typedef struct {
 struct nfsd4_callback {
 	struct nfs4_client *cb_clp;
 	struct rpc_message cb_msg;
+#define NFSD4_CALLBACK_RUNNING		(0)
+	unsigned long cb_flags;
 	const struct nfsd4_callback_ops *cb_ops;
 	struct work_struct cb_work;
 	int cb_seq_status;
@@ -747,6 +749,13 @@ extern void nfsd4_change_callback(struct nfs4_client *clp, struct nfs4_cb_conn *
 extern void nfsd4_init_cb(struct nfsd4_callback *cb, struct nfs4_client *clp,
 		const struct nfsd4_callback_ops *ops, enum nfsd4_cb_op op);
 extern bool nfsd4_run_cb(struct nfsd4_callback *cb);
+
+static inline void nfsd4_try_run_cb(struct nfsd4_callback *cb)
+{
+	if (!test_and_set_bit(NFSD4_CALLBACK_RUNNING, &cb->cb_flags))
+		WARN_ON_ONCE(!nfsd4_run_cb(cb));
+}
+
 extern void nfsd4_shutdown_callback(struct nfs4_client *);
 extern void nfsd4_shutdown_copy(struct nfs4_client *clp);
 extern struct nfs4_client_reclaim *nfs4_client_to_reclaim(struct xdr_netobj name,


### PR DESCRIPTION
### Problem

Support raised [SEE-589](https://ixsystemsinc.atlassian.net/browse/SEE-589) after a customer's NFS server (~87 NFSv4 clients) wedged for the third time. Once it happens nfsd can't expire clients any more, every later client teardown piles up behind the stuck one, and since the stuck task is the laundromat (nfsd's periodic worker that expires dead clients and cleans up NFSv4 state), all of that cleanup stops too. `rpc.nfsd` won't die on SIGKILL at that point, so only a reboot clears it.

This isn't new in 25.10.4. As per the attached debugs it hit twice on 6.12.15 (Mar 4 and Jun 20) and once on 6.12.91 (Jul 9), with the same stack every time:

```
INFO: task kworker/u128:11:979462 blocked for more than 120 seconds.
      Tainted: P        W  OE      6.12.15-production+truenas #1
task:kworker/u128:11 state:D stack:0     pid:979462 tgid:979462 ppid:2      flags:0x00004000
Workqueue: nfsd4 laundromat_main [nfsd]
Call Trace:
 <TASK>
 __schedule+0x461/0xa10
 schedule+0x27/0xd0
 nfsd4_shutdown_callback+0xfe/0x140 [nfsd]
 __destroy_client+0x1fa/0x2b0 [nfsd]
 nfs4_process_client_reaplist+0xa9/0x130 [nfsd]
 laundromat_main+0x1f1/0xa10 [nfsd]
 process_one_work+0x180/0x3a0
 worker_thread+0x2da/0x420
 kthread+0xcf/0x100
 ret_from_fork+0x31/0x50
```

### Root cause

NFSv4 hands clients delegations so they can cache a file locally, and the server has to call the client back to take one away. Each of those callbacks takes a count on `cl_cb_inflight`, and only [`nfsd41_destroy_cb()`](https://github.com/truenas/linux/blob/truenas/linux-6.12/fs/nfsd/nfs4callback.c#L1201) drops it again.

There is one callback object per delegation, so if a delegation gets broken twice, both breaks queue the same work item. The first callback RPC fails, [`nfsd4_cb_release()`](https://github.com/truenas/linux/blob/truenas/linux-6.12/fs/nfsd/nfs4callback.c#L1362) tries to requeue it for a retry, [`nfsd4_queue_cb()`](https://github.com/truenas/linux/blob/truenas/linux-6.12/fs/nfsd/nfs4callback.c#L981) returns false because it is already queued from the second break, and we ignore that. Nothing retries, and nothing drops the count.

[`nfsd4_shutdown_callback()`](https://github.com/truenas/linux/blob/truenas/linux-6.12/fs/nfsd/nfs4callback.c#L1382) waits for that count to hit zero before the client can be freed, so teardown blocks there forever. Hitting it needs a write delegation broken by a reader and then a writer, plus a callback that fails. The client itself doesn't have to be broken for that: a short network blip, or a reconnect that resets the backchannel, is enough.

### Fix

Two upstream cherry-picks, no local changes. Neither is in 6.12.y yet.

- 1054e8ffc5c4 adds a `NFSD4_CALLBACK_RUNNING` flag on the callback, so a second break on a delegation that is already being recalled returns early instead of queueing the same work item again. In mainline since v6.15.
- [fa183d59e531](https://git.kernel.org/pub/scm/linux/kernel/git/cel/linux.git/commit/?h=nfsd-next&id=fa183d59e531e016d4495e21f00d80c63aebd907) clears that flag when the queue attempt fails. Without it the flag sticks and every later recall on that delegation gets skipped, so the first commit shouldn't go in alone. Queued in nfsd-next with a Fixes: tag against 1054e8ffc5c4 and Cc: stable, so it travels with it.

### Testing

Two QEMU VMs, same rig: unpatched 6.12.95 and the [patched build](http://jenkins.eng.ixsystems.net:8080/job/goldeye/job/custom/133/artifact/TrueNAS-SCALE-25.10.1-MASTER-20260806-152447.iso) on 6.12.99. An NFS client in a netns takes a write delegation, traffic to it is dropped, the lease is broken twice (read open then write open), with a kretprobe on `nfsd4_queue_cb`.

Unpatched leaked on 14 of 14 iterations. Each leak left another task stuck in `nfsd4_shutdown_callback`, 15 by the end, and those clients could not be torn down at all.

Patched was clean on 23 of 23, no leaks and nothing stuck. Client teardown and NFS stop/start both complete immediately. 38 delegation recall cycles all served in about 1ms, and a mixed soak of clean recalls, double breaks and locks showed every queued callback destroyed with no skew. No new WARNs on either VM.

Confirmed both commits are actually in the patched kernel: `struct nfsd4_callback` gained `cb_flags`, and `nfsd_break_deleg_cb` disassembles to the `test_and_set_bit` gate plus the `clear_bit` on the failed queue path.
