### PR TITLE
NAS-142826 / 27.0.0-BETA.1 / drivetemp: fix error handling and parsing in the SCSI LOG SENSE path

### DIFF
--- a/drivers/hwmon/drivetemp.c
+++ b/drivers/hwmon/drivetemp.c
@@ -348,20 +348,22 @@ static int drivetemp_retrieve_temp_log(struct drivetemp_data *st,
 	err = scsi_execute_cmd(st->sdev, scsi_cmd, REQ_OP_DRV_IN, buf,
 			TEMP_LOG_PAGE_LEN, 10 * HZ, 5, NULL);
 	if (err)
-		return (err);
+		return err > 0 ? -EIO : err;
 
 	page_len = min(get_unaligned_be16(&buf[TEMP_LOG_LEN_OFFSET]),
 		TEMP_LOG_PAGE_LEN - TEMP_LOG_HEADER_LEN) + TEMP_LOG_HEADER_LEN;
 
 	while (i + TEMP_LOG_PARAM_HEADER_LEN <= page_len) {
-		u8 param_len = (u8) buf[i + 3] + TEMP_LOG_PARAM_HEADER_LEN;
+		unsigned int param_len = (u8) buf[i + 3] + TEMP_LOG_PARAM_HEADER_LEN;
 		u16 param_code = get_unaligned_be16(&buf[i]);
 		if (i + param_len > page_len)
 			break;
-		if (param_code == 0x0)
-			*temp = (u8) buf[i + TEMP_LOG_PARAM_TEMP_OFFSET];
-		if (reftemp && param_code == 0x1)
-			*reftemp = (u8) buf[i + TEMP_LOG_PARAM_TEMP_OFFSET];
+		if (param_len > TEMP_LOG_PARAM_TEMP_OFFSET) {
+			if (param_code == 0x0)
+				*temp = (u8) buf[i + TEMP_LOG_PARAM_TEMP_OFFSET];
+			if (reftemp && param_code == 0x1)
+				*reftemp = (u8) buf[i + TEMP_LOG_PARAM_TEMP_OFFSET];
+		}
 		i += param_len;
 	}
 


### PR DESCRIPTION
Jira: https://ixsystems.atlassian.net/browse/NAS-142826

Split out of #347 at review request. One commit, `drivers/hwmon/drivetemp.c` only, no ABI change and no behaviour change on a drive whose LOG SENSE succeeds. The `temp1_crit` to `temp1_max` retier and the subpage 02h read stay on #347.

All in `drivetemp_retrieve_temp_log()`, the SCSI log-page path added in 06ff843d70d7:

- `scsi_execute_cmd()` returns the positive `scmd->result` on CHECK CONDITION. `hwmon_attr_show()` only rejects negative returns, so an uninitialised stack `long` reaches userspace as the temperature. Normalise to `-EIO`, as `drivetemp_scsi_command()` already does since upstream 82163d63ae7a (which we also carry on 6.12 as 42268d885e44).
- `param_len` is a `u8` holding `buf[i + 3] + 4`. A length byte of `0xFC` wraps it to 0 and the loop never advances, hanging the sysfs read with `st->lock` held. Use `unsigned int`.
- The loop checks `i + param_len <= page_len` but reads the temperature at `buf[i + 5]`, which a parameter shorter than six bytes does not cover. Skip such parameters.

Base `truenas/linux-6.18` @ 580caa3a792d. Applies to `truenas/linux-6.12` unchanged with `Fixes: 43ff910ef5cc`.

Verification: `drivetemp.o` cross-compiles clean for x86_64 including `W=1` (`x86_64_defconfig` + `CONFIG_TRUENAS=y` + `CONFIG_SENSORS_DRIVETEMP=m`). `checkpatch.pl --strict` reports no errors or warnings. Not run on hardware; nothing here alters the success path.
