### PR TITLE
NAS-143100 / 27.0.0-BETA.1 / audit: do not follow a stale filename->aname back-pointer

### DIFF
--- a/kernel/auditsc.c
+++ b/kernel/auditsc.c
@@ -2259,6 +2259,24 @@ static void audit_copy_inode(struct audit_names *name,
 	audit_copy_fcaps(name, dentry);
 }
 
+/*
+ * Find the audit_names record this context holds for @name.  io_uring can make
+ * a filename outlive the context its record was created in, so the record is
+ * looked up by identity among the records this context actually owns rather
+ * than followed through the filename's ->aname back-pointer, which nothing
+ * invalidates.
+ */
+static struct audit_names *audit_name_lookup(struct audit_context *ctx,
+					     const struct filename *name)
+{
+	struct audit_names *n;
+
+	list_for_each_entry_reverse(n, &ctx->names_list, list)
+		if (n->name == name)
+			return n;
+	return NULL;
+}
+
 /**
  * __audit_inode - store the inode and device from a lookup
  * @name: name being audited
@@ -2299,10 +2317,10 @@ void __audit_inode(struct filename *name, const struct dentry *dentry,
 		goto out_alloc;
 
 	/*
-	 * If we have a pointer to an audit_names entry already, then we can
-	 * just use it directly if the type is correct.
+	 * If this context already holds a record for this filename, use it
+	 * directly, provided the type is right.
 	 */
-	n = name->aname;
+	n = audit_name_lookup(context, name);
 	if (n) {
 		if (parent) {
 			if (n->type == AUDIT_TYPE_PARENT ||


### PR DESCRIPTION
Fixes the panics seen on 6.18 during truenas_s3 testing. They all trace to one bug, a use-after-free in `__audit_inode()` reached from io_uring path operations, analysed by @anodos325 from the pstore dumps. Reproducible on both our 6.18 and 6.12 trees, but scoped to 6.18 here since 6.12 has no io_uring callers that pass pathnames, Samba's `vfs_io_uring` only submits fd-based data ops which take no `struct filename`. One thing to call out, clearing `->aname` alone isn't enough. It covers the task-work path but not `io-wq`, where the worker can load the pointer before the submitter clears it and dereference it after, so the patch also validates the pointer in `__audit_inode()` before using it. One behaviour change too, `io_uring_enter(2)` no longer logs its own PATH record for these ops. That was the broken one anyway, it reported an inode `io_uring_enter(2)` never looked up. The op is still audited on the URINGOP event and audit used to log `name=(null)` for these, now it logs the real path.

This is a targeted fix rather than mainline's approach, and that's the reason for keeping it downstream only. [Mainline fixed it in io_uring instead](https://www.mail-archive.com/audit@vger.kernel.org/msg01671.html), so it never hands audit a filename from another context. Ours just stops audit following the stale pointer. I did try backporting mainline's, but it's one commit out of a series that rewrites `getname_flags()`, 266 lines across 6 files including `linux/fs.h`. Since we update our kernel trees actively, that would drift us from LTS. Stable can't take mainline's either, it caps patches at 100 lines, and the series has no `Fixes:` tag or `Cc: stable` so the tooling never saw it. 27 moves to a 7.x kernel which already has the proper fix, so this carry has a natural end.

## Testing

Ran under KASAN with audit rules loaded, driving the affected opcodes over both the io-wq and task-work paths. 6.18.48 goes from 4879 reports to 0, and 0 with no rules loaded. Ordinary syscall audit records are unchanged, and an inode-keyed rule still matches the io_uring operations, checked against stock and patched kernels.